### PR TITLE
Bulk email: comma-separated recipients + re-enable admin guards

### DIFF
--- a/src/routes/email-sender/+page.server.ts
+++ b/src/routes/email-sender/+page.server.ts
@@ -14,9 +14,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 
   const userId = session && session.user?.id || null;
   
-  // if (ADMIN_ID !== userId) {
-  //   throw redirect(302, '/')
-  // }
+  if (ADMIN_ID !== userId) {
+    throw redirect(302, '/')
+  }
 
   // Get all users with basic info
   const { data: users, error } = await supabase
@@ -50,9 +50,9 @@ export const actions: Actions = {
 
     const userId = session && session.user.id || null;
     
-    // if (ADMIN_ID !== userId) {
-    //   throw redirect(302, '/')
-    // }
+    if (ADMIN_ID !== userId) {
+      throw redirect(302, '/')
+    }
 
     const data = await request.formData();
     const recipientType = data.get('recipientType') as string;
@@ -144,9 +144,9 @@ export const actions: Actions = {
 
     const userId = session && session.user.id || null;
 
-    // if (ADMIN_ID !== userId) {
-    //   throw redirect(302, '/');
-    // }
+    if (ADMIN_ID !== userId) {
+      throw redirect(302, '/');
+    }
 
     const data = await request.formData();
     const email = data.get('streakEmail') as string;


### PR DESCRIPTION
## Summary
- Support comma-separated emails for custom recipient in email sender
- Re-enable admin auth guards that were temporarily commented out

## Test plan
- [ ] Verify custom recipient field accepts comma-separated emails and sends to all
- [ ] Verify non-admin users are redirected to `/` when accessing email sender routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)