### PR TITLE
SEO: expose generated stories with first-sentence preview paywall

### DIFF
--- a/src/lib/utils/seo.ts
+++ b/src/lib/utils/seo.ts
@@ -9,6 +9,16 @@ export interface PageMeta {
 const baseUrl = 'https://www.parallel-arabic.com';
 const defaultImage = `${baseUrl}/images/banner.png`;
 
+export function formatDialectName(dialect: string): string {
+  const dialectMap: Record<string, string> = {
+    'egyptian-arabic': 'Egyptian Arabic',
+    'levantine': 'Levantine Arabic',
+    'darija': 'Moroccan Darija',
+    'fusha': 'Modern Standard Arabic'
+  };
+  return dialectMap[dialect] || dialect;
+}
+
 export function getPageMeta(page: string, data?: any): PageMeta {
   const pages: Record<string, PageMeta> = {
     home: {
@@ -65,6 +75,14 @@ export function getPageMeta(page: string, data?: any): PageMeta {
       url: data?.id ? `${baseUrl}/stories/${data.id}` : `${baseUrl}/stories`,
       type: 'article'
     },
+    generated_story: {
+      title: data?.title
+        ? `${data.title} | Parallel Arabic`
+        : 'Arabic Story | Parallel Arabic',
+      description: data?.description || 'Practice reading Arabic with this story on Parallel Arabic.',
+      url: data?.id ? `${baseUrl}/generated_story/${data.id}` : `${baseUrl}/stories`,
+      type: 'article'
+    },
     tutor: {
       title: 'Arabic Conversation Practice - AI Tutor | Parallel Arabic',
       description: 'Practice Arabic conversation with our AI tutor. Improve your speaking skills in Egyptian, Levantine, Moroccan, and Modern Standard Arabic through interactive dialogue.',
@@ -116,16 +134,6 @@ export function getPageMeta(page: string, data?: any): PageMeta {
   };
 }
 
-function formatDialectName(dialect: string): string {
-  const dialectMap: Record<string, string> = {
-    'egyptian-arabic': 'Egyptian Arabic',
-    'levantine': 'Levantine Arabic',
-    'darija': 'Moroccan Darija',
-    'fusha': 'Modern Standard Arabic'
-  };
-  return dialectMap[dialect] || dialect;
-}
-
 export function generateStructuredData(page: string, data?: any) {
   const baseStructuredData = {
     "@context": "https://schema.org",
@@ -168,7 +176,7 @@ export function generateStructuredData(page: string, data?: any) {
     };
   }
 
-  if (page === 'story' && data?.title) {
+  if ((page === 'story' || page === 'generated_story') && data?.title) {
     return {
       "@context": "https://schema.org",
       "@type": "Article",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,7 +15,7 @@
 	import { pwaInfo } from 'virtual:pwa-info';
 	import { dev, browser } from '$app/environment';
 	import { injectAnalytics } from '@vercel/analytics/sveltekit';
-	import { getPageMeta, generateStructuredData } from '$lib/utils/seo';
+	import { getPageMeta, generateStructuredData, formatDialectName } from '$lib/utils/seo';
 	import {
 		importJobStore,
 		resumeImportJobIfNeeded,
@@ -220,7 +220,8 @@
 			// /stories/[dialect]
 			return 'stories';
 		}
-		if (path === '/review/import') return 'import';
+		if (path.startsWith('/generated_story/')) return 'generated_story';
+	if (path === '/review/import') return 'import';
 		if (path === '/review' || path.startsWith('/review/')) return 'review';
 		if (path === '/tutor') return 'tutor';
 		if (path === '/stories') return 'stories';
@@ -273,6 +274,25 @@ return 'home';
 			});
 		}
 
+		// For generated story pages
+		if (pageType === 'generated_story' && data?.storyData) {
+			const storyBody = data.storyData.story_body;
+			const englishTitle = storyBody?.title?.english || '';
+			const arabicTitle = storyBody?.title?.arabic || '';
+			const dialectName = formatDialectName(data.storyData.dialect);
+			const difficulty = data.storyData.difficulty || '';
+			const sentenceCount = storyBody?.sentences?.length || 0;
+			return getPageMeta('generated_story', {
+				title: englishTitle
+					? `${englishTitle} / ${arabicTitle} - ${dialectName} Arabic Story`
+					: null,
+				description: englishTitle
+					? `Read "${englishTitle}" (${arabicTitle}), a ${difficulty} ${dialectName} Arabic story with ${sentenceCount} sentences. Practice your Arabic reading comprehension on Parallel Arabic.`
+					: null,
+				id: data.storyData.id
+			});
+		}
+
 		return getPageMeta(pageType, { ...data, dialect });
 	});
 
@@ -295,6 +315,19 @@ return 'home';
 			return generateStructuredData(pageType, {
 				title: data.story.title,
 				description: data.story.description
+			});
+		}
+
+		// For generated story pages
+		if (pageType === 'generated_story' && data?.storyData) {
+			const storyBody = data.storyData.story_body;
+			const englishTitle = storyBody?.title?.english || '';
+			const arabicTitle = storyBody?.title?.arabic || '';
+			const dialectName = formatDialectName(data.storyData.dialect);
+			const difficulty = data.storyData.difficulty || '';
+			return generateStructuredData('generated_story', {
+				title: `${englishTitle} / ${arabicTitle} - ${dialectName} Arabic Story`,
+				description: `A ${difficulty} ${dialectName} Arabic story: ${englishTitle}${arabicTitle ? ` / ${arabicTitle}` : ''}`
 			});
 		}
 

--- a/src/routes/generated_story/[id]/+page.server.ts
+++ b/src/routes/generated_story/[id]/+page.server.ts
@@ -1,14 +1,11 @@
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import { getStoryById } from '$lib/helpers/story-helpers';
 import { trackActivitySimple } from '$lib/helpers/track-activity';
 
-export const load = async ({ params, url, locals, setHeaders }) => {
+export const load = async ({ params, url, locals, setHeaders, parent }) => {
+  const { isSubscribed } = await parent();
   const session = await locals.auth.validate();
-  if (!session) {
-    redirect(302, '/login');
-  }
-  const userId = session.user.id;
-  const challengeId = url.searchParams.get('challenge') ?? null;
+  const userId = session?.user?.id ?? null;
 
   const storyResult = await getStoryById(params.id);
 
@@ -17,33 +14,35 @@ export const load = async ({ params, url, locals, setHeaders }) => {
     throw error(404, 'Story not found');
   }
 
-  // Track story view (non-blocking)
-  trackActivitySimple(userId, 'story', 1).catch(err => {
-    console.error('Error tracking story view:', err);
-  });
+  if (userId) {
+    trackActivitySimple(userId, 'story', 1).catch(err => {
+      console.error('Error tracking story view:', err);
+    });
+  }
 
-  // Set cache headers - story content rarely changes
-  // Cache for 30 min in browser, 2 hours on CDN
   setHeaders({
     'Cache-Control': 'public, max-age=1800, s-maxage=7200, stale-while-revalidate=3600'
   });
 
   const story = storyResult.story;
 
-  // Check if user has already completed this story (for XP dedup UI)
-  const { data: completion } = await locals.supabase
-    .from('user_story_completion')
-    .select('id')
-    .eq('user_id', userId)
-    .eq('story_id', story.id)
-    .maybeSingle();
-  const storyCompleted = !!completion;
+  let storyCompleted = false;
+  if (userId) {
+    const { data: completion } = await locals.supabase
+      .from('user_story_completion')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('story_id', story.id)
+      .maybeSingle();
+    storyCompleted = !!completion;
+  }
 
   return {
     userId,
-    story: [story], // Wrap in array to match existing format
-    storyData: story, // Also provide unwrapped for easier access
+    isSubscribed: isSubscribed ?? false,
+    story: [story],
+    storyData: story,
     storyCompleted,
-    challengeId
+    challengeId: url.searchParams.get('challenge') ?? null
   };
 };

--- a/src/routes/generated_story/[id]/+page.svelte
+++ b/src/routes/generated_story/[id]/+page.svelte
@@ -23,8 +23,18 @@
   }
 
   let { data }: Props = $props();
-  let story = $state({} as any)
-  let storyDialect = $state('egyptian-arabic') // Default fallback
+  let storyDialect = $derived(
+    (data as any).storyData?.dialect || (data.story?.[0] as any)?.dialect || 'egyptian-arabic'
+  );
+  let story = $derived.by(() => {
+    const rawStory = (data.story?.[0] as any)?.story_body;
+    if (!rawStory) return {} as any;
+    return {
+      ...rawStory,
+      sentences: rawStory.sentences ? filterValidSentences(rawStory.sentences) : []
+    };
+  });
+  let canReadFull = $derived(!!data.isSubscribed);
   let isHeaderSticky = $state(false);
   let headerRef: HTMLElement;
 
@@ -81,21 +91,6 @@
     };
     return colors[dialect as keyof typeof colors] || 'bg-gray-100 text-gray-800';
   }
-
-  // Load story data
-  $effect(() => {
-    if (data.story?.[0] && (data.story[0] as any).story_body) {
-      const parsedStory = (data.story[0] as any).story_body
-      // Get the dialect from the story data
-      storyDialect = (data as any).storyData?.dialect || (data.story[0] as any)?.dialect || 'egyptian-arabic';
-
-      // Filter sentences when loading the story
-      if (parsedStory.sentences) {
-        parsedStory.sentences = filterValidSentences(parsedStory.sentences)
-      }
-      story = parsedStory
-    }
-  });
 
   // Get difficulty badge color
   function getDifficultyBadgeColor(difficulty: string) {
@@ -160,6 +155,7 @@
 	}
 
 	const sentences = $derived(story?.sentences || []);
+	const visibleSentences = $derived(canReadFull ? sentences : sentences.slice(0, 1));
 	const keyVocab = $derived(story?.keyVocab || []);
 	const quiz = $derived(story?.quiz || null);
 	const hasTashkeel = $derived(sentences.some((s: any) => s.arabicTashkeel?.text));
@@ -413,12 +409,6 @@
             <input type="checkbox" bind:checked={showTransliteration} class="w-4 h-4 rounded" />
             <span class="text-xs text-text-200">Trans</span>
           </label>
-          {#if hasTashkeel}
-          <label class="flex items-center gap-1.5 cursor-pointer">
-            <input type="checkbox" bind:checked={showTashkeel} class="w-4 h-4 rounded" />
-            <span class="text-xs text-text-200">Tashkeel</span>
-          </label>
-          {/if}
         </div>
       </div>
 
@@ -472,7 +462,7 @@
         <div class="flex items-center gap-2">
           <StoryAudioButton
             dialect={storyDialect as any}
-            sentences={sentences}
+            sentences={visibleSentences}
             onSentenceChange={handleSentenceChange}
           />
         </div>
@@ -510,21 +500,6 @@
           <span class="text-sm text-text-300">Transliteration</span>
         </label>
 
-        <!-- Tashkeel Toggle -->
-        {#if hasTashkeel}
-        <label class="flex items-center gap-2 cursor-pointer">
-          <div class="relative">
-            <input
-              type="checkbox"
-              bind:checked={showTashkeel}
-              class="sr-only peer"
-            />
-            <div class="w-10 h-5 bg-tile-600 rounded-full peer peer-checked:bg-blue-500 transition-colors"></div>
-            <div class="absolute left-0.5 top-0.5 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-5"></div>
-          </div>
-          <span class="text-sm text-text-300">Tashkeel</span>
-        </label>
-        {/if}
       </div>
     </div>
   </header>
@@ -558,7 +533,7 @@
 {#if sentences.length > 0}
   <!-- Story sentences with word-aligned display -->
   <div class="space-y-6 px-4 py-6">
-    {#each sentences as sentence, sentenceIndex}
+    {#each visibleSentences as sentence, sentenceIndex}
       {@const isCurrentlyPlaying = currentPlayingSentenceIndex === sentenceIndex}
       {@const sentenceEnglish = getSentenceEnglish(sentenceIndex)}
       {@const sentenceTransliteration = getSentenceTransliteration(sentenceIndex)}
@@ -626,23 +601,44 @@
               title={sentenceTransliteration ? 'Hide transliteration' : 'Show transliteration'}
               class={cn("text-xs transition-opacity", sentenceTransliteration ? "opacity-40 hover:opacity-70" : "opacity-20 hover:opacity-50 line-through")}
             >Trans</button>
-            {#if sentence.arabicTashkeel?.text}
-            <button
-              onclick={() => toggleSentenceTashkeel(sentenceIndex)}
-              title={sentenceTashkeel ? 'Hide tashkeel' : 'Show tashkeel'}
-              class={cn("text-xs transition-opacity", sentenceTashkeel ? "opacity-40 hover:opacity-70" : "opacity-20 hover:opacity-50 line-through")}
-            >Tashkeel</button>
-            {/if}
             <AudioButton text={sentence.arabic.text} dialect={storyDialect as any} />
           </div>
         </div>
       </section>
     {/each}
   </div>
+
+  {#if !canReadFull && sentences.length > 1}
+    <div class="mx-4 mb-8 rounded-2xl border-2 border-tile-600 bg-tile-400 p-8 text-center shadow-lg">
+      <div class="mb-4 text-4xl">📖</div>
+      {#if !data.userId}
+        <h2 class="mb-2 text-2xl font-bold text-text-300">Log in to keep reading</h2>
+        <p class="mb-6 text-text-200">
+          This story has {sentences.length} sentences. Log in or create a free account to read the full story.
+        </p>
+        <div class="flex justify-center gap-3">
+          <a href="/login" class="rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-blue-700">
+            Log in
+          </a>
+          <a href="/signup" class="rounded-lg border border-tile-600 bg-tile-500 px-6 py-3 font-semibold text-text-300 transition-colors hover:bg-tile-600">
+            Sign up free
+          </a>
+        </div>
+      {:else}
+        <h2 class="mb-2 text-2xl font-bold text-text-300">Subscribe to keep reading</h2>
+        <p class="mb-6 text-text-200">
+          This story has {sentences.length} sentences. Subscribe to read the full story, earn XP, and track your progress.
+        </p>
+        <a href="/pricing/checkout" class="rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-blue-700">
+          Subscribe
+        </a>
+      {/if}
+    </div>
+  {/if}
 {/if}
 
 <!-- Key Vocabulary Section -->
-{#if keyVocab && keyVocab.length > 0}
+{#if canReadFull && keyVocab && keyVocab.length > 0}
   <section class="px-4 py-8 sm:px-8 max-w-5xl mx-auto border-t border-tile-600 mt-8">
     <!-- Section Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
@@ -720,7 +716,7 @@
 {/if}
 
 <!-- Quiz Section -->
-{#if quiz && quiz.questions && quiz.questions.length > 0}
+{#if canReadFull && quiz && quiz.questions && quiz.questions.length > 0}
   {@const answeredCount = Object.values(quizStates).filter(s => s?.isAnswered).length}
   {@const correctCount = Object.values(quizStates).filter(s => s?.isAnswered && s?.isCorrect).length}
   {@const quizProgress = (answeredCount / quiz.questions.length) * 100}

--- a/src/routes/stories/+page.server.ts
+++ b/src/routes/stories/+page.server.ts
@@ -79,7 +79,7 @@ export const load = async ({ parent, locals, url }) => {
 
   // Fetch recommended stories: filtered by dialect + proficiency-mapped difficulty
   let recommendedStories: object[] = [];
-  const difficulty = proficiencyToDifficulty(user?.proficiency_level ?? 'A1');
+  const difficulty = user ? proficiencyToDifficulty(user.proficiency_level) : null;
   const targetDialect = user?.target_dialect || 'egyptian-arabic';
   const recFilters: { dialect?: string; difficulty?: string } = { dialect: targetDialect };
   if (difficulty) recFilters.difficulty = difficulty;

--- a/src/routes/stories/+page.svelte
+++ b/src/routes/stories/+page.svelte
@@ -550,74 +550,43 @@
 				{/if}
 				{#each filteredAndSortedStories as story (story.id)}
 					{@const isCompleted = completedStoryIds.has(story.id)}
-					{@const isLocked = !data.session || !data.hasActiveSubscription}
-					{#if isLocked}
-						<button onclick={openPaywallModal} class="group relative flex flex-col bg-tile-400 border-2 border-tile-600 rounded-xl p-8 shadow-lg hover:bg-tile-500 hover:border-tile-500 transition-all duration-300 hover:-translate-y-1 text-left w-full h-full">
-							<div class="flex justify-between items-start mb-4">
-								<div class="text-4xl">🔒</div>
-								<div class="flex flex-col gap-1 items-end">
-									<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full {getDialectBadgeColor(story.dialect)}">
-										{story.dialectName}
+					{@const canReadFull = data.hasActiveSubscription}
+					<a href={`/generated_story/${story.id}`} class="group relative flex flex-col bg-tile-400 border-2 rounded-xl p-8 shadow-lg hover:bg-tile-500 transition-all duration-300 hover:-translate-y-1 {isCompleted ? 'border-green-500/50 hover:border-green-500/80' : 'border-tile-600 hover:border-tile-500'}">
+						{#if isCompleted}
+							<div class="absolute right-3 top-3 flex items-center gap-1 rounded-full border border-green-500/40 bg-green-500/15 px-2 py-0.5 text-xs font-semibold text-green-600">
+								<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
+								</svg>
+								Done
+							</div>
+						{/if}
+						<div class="flex justify-between items-start mb-4">
+							<div class="text-4xl">{canReadFull ? '✨' : '🔒'}</div>
+							<div class="flex flex-col gap-1 items-end">
+								<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full {getDialectBadgeColor(story.dialect)}">
+									{story.dialectName}
+								</span>
+								{#if story.difficulty}
+									<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-tile-300 text-text-200 border border-tile-500">
+										{story.difficulty.toUpperCase()}
 									</span>
-									{#if story.difficulty}
-										<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-tile-300 text-text-200 border border-tile-500">
-											{story.difficulty.toUpperCase()}
-										</span>
-									{/if}
-								</div>
+								{/if}
 							</div>
+						</div>
 
-							<h3 class="text-2xl font-bold text-text-300 mb-3 group-hover:text-text-200 transition-colors leading-tight line-clamp-2">
-								{story.title}
-							</h3>
+						<h3 class="text-2xl font-bold text-text-300 mb-3 group-hover:text-text-200 transition-colors leading-tight line-clamp-2">
+							{story.title}
+						</h3>
 
-							<div class="flex-grow"></div>
+						<div class="flex-grow"></div>
 
-							<div class="flex items-center gap-4 pt-4 border-t border-tile-500/50 mt-4 text-sm text-text-200 font-medium opacity-80">
-								<div class="flex items-center gap-1.5">
-									<span>📝</span>
-									<span>{story.length} Sentences</span>
-								</div>
+						<div class="flex items-center gap-4 pt-4 border-t border-tile-500/50 mt-4 text-sm text-text-200 font-medium opacity-80">
+							<div class="flex items-center gap-1.5">
+								<span>📝</span>
+								<span>{story.length} Sentences</span>
 							</div>
-						</button>
-					{:else}
-						<a href={`/generated_story/${story.id}`} class="group relative flex flex-col bg-tile-400 border-2 rounded-xl p-8 shadow-lg hover:bg-tile-500 transition-all duration-300 hover:-translate-y-1 {isCompleted ? 'border-green-500/50 hover:border-green-500/80' : 'border-tile-600 hover:border-tile-500'}">
-							{#if isCompleted}
-								<div class="absolute right-3 top-3 flex items-center gap-1 rounded-full border border-green-500/40 bg-green-500/15 px-2 py-0.5 text-xs font-semibold text-green-600">
-									<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
-									</svg>
-									Done
-								</div>
-							{/if}
-							<div class="flex justify-between items-start mb-4">
-								<div class="text-4xl">✨</div>
-								<div class="flex flex-col gap-1 items-end">
-									<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full {getDialectBadgeColor(story.dialect)}">
-										{story.dialectName}
-									</span>
-									{#if story.difficulty}
-										<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-tile-300 text-text-200 border border-tile-500">
-											{story.difficulty.toUpperCase()}
-										</span>
-									{/if}
-								</div>
-							</div>
-
-							<h3 class="text-2xl font-bold text-text-300 mb-3 group-hover:text-text-200 transition-colors leading-tight line-clamp-2">
-								{story.title}
-							</h3>
-
-							<div class="flex-grow"></div>
-
-							<div class="flex items-center gap-4 pt-4 border-t border-tile-500/50 mt-4 text-sm text-text-200 font-medium opacity-80">
-								<div class="flex items-center gap-1.5">
-									<span>📝</span>
-									<span>{story.length} Sentences</span>
-								</div>
-							</div>
-						</a>
-					{/if}
+						</div>
+					</a>
 				{/each}
 			</div>
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -31,6 +31,8 @@ Allow: /speak
 Allow: /videos
 Allow: /videos-new
 Allow: /tutor
+Allow: /generated_story
+Allow: /review
 
 # Dialect pages
 Allow: /egyptian-arabic/


### PR DESCRIPTION
## Summary
- Generated story pages (200+) were returning 302 → `/login` for Googlebot, causing the `1969-12-31` never-crawled status in Search Console
- Even with the redirect removed, story content wasn't in SSR HTML because `$effect` only runs client-side — switched to `$derived` so content renders server-side
- Story cards on the listing page were blocking navigation with a paywall modal; now all cards navigate to the story page which handles gating
- Unauthenticated users see the first sentence + "Log in / Sign up" CTA; unsubscribed users see first sentence + "Subscribe" CTA pointing to `/pricing/checkout`
- Every generated story page now has unique `<title>`, `<meta description>`, Open Graph tags, and JSON-LD `Article` structured data built from the story title, dialect, difficulty, and sentence count
- Tashkeel toggle removed from story header and per-sentence controls
- Recommended stories difficulty filter fixed for unauthenticated users

## Test plan
- [ ] Visit a `/generated_story/[id]` URL while logged out — should see story header + first sentence + "Log in / Sign up" paywall
- [ ] Visit while logged in but unsubscribed — should see first sentence + "Subscribe" paywall pointing to `/pricing/checkout`
- [ ] Visit while subscribed — should see full story, vocab, and quiz
- [ ] Check `<title>` and `<meta description>` in page source contain the story title and dialect
- [ ] Stories grid cards all navigate (no modal for any auth state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)