### PR TITLE
Privacy policy, model update, tashkeel fix

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -32,6 +32,7 @@
           <li><a href="https://github.com/selmetwa/parallel-arabic" target="_blank" class="hover:text-text-100 transition-all duration-200 hover:translate-x-1 inline-block">Source Code</a></li>
           <li><a href="/keyboard" class="hover:text-text-100 transition-all duration-200 hover:translate-x-1 inline-block">Virtual Keyboard</a></li>
           <li><a href="/sitemap.xml" class="hover:text-text-100 transition-all duration-200 hover:translate-x-1 inline-block">Sitemap</a></li>
+          <li><a href="/privacy" class="hover:text-text-100 transition-all duration-200 hover:translate-x-1 inline-block">Privacy Policy</a></li>
         </ul>
       </div>
       <div class="space-y-4">

--- a/src/lib/utils/add-tashkeel.ts
+++ b/src/lib/utils/add-tashkeel.ts
@@ -85,7 +85,7 @@ ${arabicSentences.map((s, i) => `${i + 1}. ${s}`).join('\n')}`;
 
 			const originalWordCount = wordCount(stripTashkeel(original));
 			const resultWordCount = wordCount(stripTashkeel(tashkeelText));
-			if (Math.abs(originalWordCount - resultWordCount) > 1) {
+			if (originalWordCount !== resultWordCount) {
 				console.warn(
 					`[addTashkeel] Word count mismatch for sentence ${i}: ${originalWordCount} vs ${resultWordCount}`
 				);

--- a/src/lib/utils/gemini-api-retry.ts
+++ b/src/lib/utils/gemini-api-retry.ts
@@ -1,7 +1,7 @@
 /**
  * Retry utility for Gemini API calls with exponential backoff
  * Handles 503 (Service Unavailable) and other 5xx errors from Gemini API
- * Model priority: gemini-2.5-flash
+ * Model priority: gemini-3.1-flash-lite-preview
  */
 
 import type { GoogleGenAI } from '@google/genai';
@@ -21,7 +21,7 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
 	maxDelayMs: 16000, // Max 16 seconds delay
 	backoffMultiplier: 2, // Double the delay each time
 	retryableStatusCodes: [503, 500, 502, 504, 429], // Service Unavailable, Internal Server Error, Bad Gateway, Gateway Timeout, Too Many Requests
-	fallbackModels: ['gemini-2.5-flash'] // Fallback models to use if all retries fail
+	fallbackModels: ['gemini-3.1-flash-lite-preview'] // Fallback models to use if all retries fail
 };
 
 /**
@@ -204,7 +204,7 @@ export async function generateContentWithRetry(
 	options: RetryOptions = {}
 ) {
 	const retryOptions = { ...DEFAULT_OPTIONS, ...options };
-	const originalModel = params.model || 'gemini-2.5-flash';
+	const originalModel = params.model || 'gemini-3.1-flash-lite-preview';
 	const triedModels = new Set<string>([originalModel]);
 
 	try {

--- a/src/lib/utils/gemini-helper.ts
+++ b/src/lib/utils/gemini-helper.ts
@@ -32,7 +32,7 @@ export async function callGeminiWithSchema<T>(
 	options: GeminiCallOptions = {}
 ): Promise<T> {
 	const {
-		model = 'gemini-2.5-flash',
+		model = 'gemini-3.1-flash-lite-preview',
 		temperature = 0.7,
 		topP,
 		maxOutputTokens

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,0 +1,158 @@
+<section class="max-w-3xl mx-auto px-6 py-12">
+	<h1 class="text-4xl font-bold text-text-300 mb-2">Privacy Policy</h1>
+	<p class="text-text-200 mb-10">Last updated: April 25, 2026</p>
+
+	<div class="space-y-8 text-text-200 leading-relaxed">
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">1. Overview</h2>
+			<p>
+				Parallel Arabic ("we," "us," or "our") is an Arabic language learning platform available at
+				<a href="https://www.parallel-arabic.com" class="underline">parallel-arabic.com</a> and as a
+				mobile app. This Privacy Policy explains what information we collect, how we use it, and your
+				rights regarding your data.
+			</p>
+			<p class="mt-2">
+				By using Parallel Arabic, you agree to the practices described in this policy. If you do not
+				agree, please do not use the service.
+			</p>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">2. Information We Collect</h2>
+
+			<h3 class="text-lg font-semibold text-text-300 mb-1">Account Information</h3>
+			<p>When you create an account, we collect your email address and a password (stored securely via Supabase Auth).</p>
+
+			<h3 class="text-lg font-semibold text-text-300 mt-4 mb-1">Learning & Usage Data</h3>
+			<p>To personalize your experience and track your progress, we collect:</p>
+			<ul class="list-disc list-inside mt-2 space-y-1">
+				<li>Your target dialect and proficiency level</li>
+				<li>XP, level, and daily streak</li>
+				<li>Saved vocabulary words and review schedules (spaced repetition)</li>
+				<li>Lesson, story, and video completion history</li>
+				<li>Game progress and scores</li>
+				<li>Daily challenge completion</li>
+				<li>Leaderboard participation preference</li>
+			</ul>
+
+			<h3 class="text-lg font-semibold text-text-300 mt-4 mb-1">Voice & Audio Data</h3>
+			<p>
+				When you use speaking or pronunciation features, your microphone input is sent to Google
+				Cloud Speech-to-Text for transcription. We do not store raw audio recordings.
+			</p>
+
+			<h3 class="text-lg font-semibold text-text-300 mt-4 mb-1">Payment Information</h3>
+			<p>
+				Subscription payments are processed by Stripe. We do not store your credit card number or
+				full payment details — only a Stripe customer ID and your subscription status and end date.
+			</p>
+
+			<h3 class="text-lg font-semibold text-text-300 mt-4 mb-1">Device & Usage Analytics</h3>
+			<p>
+				We use Vercel Analytics to collect anonymized data about how the app is used (page views,
+				performance metrics). This data is not tied to your personal identity.
+			</p>
+
+			<h3 class="text-lg font-semibold text-text-300 mt-4 mb-1">Cookies & Local Storage</h3>
+			<p>
+				We use a secure, HTTP-only session cookie to keep you logged in. We also store small
+				preference values (e.g., sidebar state) in your browser's local storage. No third-party
+				advertising cookies are used.
+			</p>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">3. How We Use Your Information</h2>
+			<ul class="list-disc list-inside space-y-1">
+				<li>To operate and personalize your learning experience</li>
+				<li>To track progress, streaks, XP, and leaderboard rankings</li>
+				<li>To deliver AI-generated content (stories, lessons, sentences) via Google Gemini</li>
+				<li>To provide text-to-speech audio via ElevenLabs</li>
+				<li>To process subscription payments via Stripe</li>
+				<li>To send transactional emails (e.g., password reset) via Mailgun</li>
+				<li>To improve app performance and fix errors</li>
+			</ul>
+			<p class="mt-3">We do not sell your personal data to third parties.</p>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">4. Third-Party Services</h2>
+			<p>Parallel Arabic uses the following third-party services, each with their own privacy policies:</p>
+			<ul class="list-disc list-inside mt-2 space-y-1">
+				<li><strong>Supabase</strong> — authentication and database hosting</li>
+				<li><strong>Stripe</strong> — payment processing and subscription management</li>
+				<li><strong>Google Cloud / Google Gemini</strong> — AI content generation and speech-to-text</li>
+				<li><strong>ElevenLabs</strong> — text-to-speech audio generation</li>
+				<li><strong>Mailgun</strong> — transactional email delivery</li>
+				<li><strong>Vercel</strong> — hosting and anonymized analytics</li>
+				<li><strong>YouTube</strong> — video content and transcript processing</li>
+			</ul>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">5. Data Retention</h2>
+			<p>
+				Your account data is retained for as long as your account is active. If you delete your
+				account, we will delete your personal data within 30 days, except where we are required to
+				retain it for legal or financial purposes (e.g., Stripe transaction records).
+			</p>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">6. Children's Privacy</h2>
+			<p>
+				Parallel Arabic is not directed at children under the age of 13. We do not knowingly collect
+				personal information from children under 13. If you believe a child has provided us with
+				personal data, please contact us and we will delete it promptly.
+			</p>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">7. Your Rights</h2>
+			<p>Depending on your location, you may have the right to:</p>
+			<ul class="list-disc list-inside mt-2 space-y-1">
+				<li>Access the personal data we hold about you</li>
+				<li>Request correction of inaccurate data</li>
+				<li>Request deletion of your account and data</li>
+				<li>Export your data in a portable format</li>
+				<li>Withdraw consent at any time (where processing is based on consent)</li>
+			</ul>
+			<p class="mt-3">
+				To exercise any of these rights, contact us at
+				<a href="mailto:selmetwa@gmail.com" class="underline">selmetwa@gmail.com</a>.
+			</p>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">8. Security</h2>
+			<p>
+				We take reasonable technical measures to protect your data, including HTTPS encryption,
+				HTTP-only secure cookies, and access controls on our database. No system is 100% secure, and
+				we cannot guarantee absolute security.
+			</p>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">9. Changes to This Policy</h2>
+			<p>
+				We may update this Privacy Policy from time to time. We will notify you of material changes
+				by updating the date at the top of this page. Continued use of the app after changes
+				constitutes acceptance of the updated policy.
+			</p>
+		</div>
+
+		<div>
+			<h2 class="text-2xl font-semibold text-text-300 mb-3">10. Contact</h2>
+			<p>
+				If you have any questions about this Privacy Policy, please contact us at:
+			</p>
+			<p class="mt-2">
+				<strong>Sherif El Metwally</strong><br />
+				Parallel Arabic<br />
+				<a href="mailto:selmetwa@gmail.com" class="underline">selmetwa@gmail.com</a>
+			</p>
+		</div>
+
+	</div>
+</section>


### PR DESCRIPTION
## Summary
- Add `/privacy` page with full privacy policy (covers auth, payments, third-party services, user rights) — required for App Store submission
- Add Privacy Policy link to footer Resources section
- Switch default Gemini model from `gemini-2.5-flash` to `gemini-3.1-flash-lite-preview`
- Tighten tashkeel validation: reject output if word count differs at all (previously allowed ±1 word)

## Test plan
- [ ] Visit `/privacy` — page renders correctly
- [ ] Check footer — Privacy Policy link is visible and navigates to `/privacy`
- [ ] Trigger any AI feature (story, lesson, sentences) — confirm it uses `gemini-3.1-flash-lite-preview` in server logs
- [ ] Verify tashkeel pipeline rejects sentences with any word count mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)