### PR TITLE
Add Apple IAP via RevenueCat (App Store Guideline 3.1.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
 				"@google/generative-ai": "^0.24.1",
 				"@lucia-auth/adapter-sqlite": "^2.0.1",
 				"@lucia-auth/oauth": "^3.5.3",
+				"@revenuecat/purchases-capacitor": "^11.3.2",
+				"@revenuecat/purchases-capacitor-ui": "^11.3.2",
 				"@sentry/sveltekit": "^10.42.0",
 				"@stripe/stripe-js": "^4.1.0",
 				"@supabase/ssr": "^0.7.0",
@@ -4246,6 +4248,56 @@
 			"peerDependencies": {
 				"@redis/client": "^5.10.0"
 			}
+		},
+		"node_modules/@revenuecat/purchases-capacitor": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/@revenuecat/purchases-capacitor/-/purchases-capacitor-11.3.2.tgz",
+			"integrity": "sha512-3T4/lcAwpbPagrT4DuXvJ+8RewzFmHf3fQJQuhVy+uTQk5HGMHNlXcm2A/UdyHtWqU+/VqWbCClPFYGnpnNXAQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@revenuecat/purchases-typescript-internal-esm": "17.25.0"
+			},
+			"peerDependencies": {
+				"@capacitor/core": ">=7.0.0"
+			}
+		},
+		"node_modules/@revenuecat/purchases-capacitor-ui": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/@revenuecat/purchases-capacitor-ui/-/purchases-capacitor-ui-11.3.2.tgz",
+			"integrity": "sha512-WmXukwbRISYlSaMDP+97HVKQD2VDDXL3FzgFEVhNEjxu/Dl/hSx/AXYiQAWuSuHYaxU0dWUZZwgC+XMVjsa1Dg==",
+			"license": "MIT",
+			"dependencies": {
+				"@capacitor/core": "^7.0.0",
+				"@revenuecat/purchases-capacitor": "^10.2.4",
+				"@revenuecat/purchases-typescript-internal-esm": "17.25.0"
+			},
+			"peerDependencies": {
+				"@capacitor/core": "^7.0.0"
+			}
+		},
+		"node_modules/@revenuecat/purchases-capacitor-ui/node_modules/@revenuecat/purchases-capacitor": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/@revenuecat/purchases-capacitor/-/purchases-capacitor-10.4.0.tgz",
+			"integrity": "sha512-205im5Bs1BY8wLt+qaS0O2GTWtSHUMFc3Z8U2QaVx4EN0hHOk9gqx2bNaUEH+cOWTUPlNz9yikdiMUSTjJzwyA==",
+			"license": "MIT",
+			"dependencies": {
+				"@revenuecat/purchases-typescript-internal-esm": "14.3.0"
+			},
+			"peerDependencies": {
+				"@capacitor/core": ">=7.0.0"
+			}
+		},
+		"node_modules/@revenuecat/purchases-capacitor-ui/node_modules/@revenuecat/purchases-capacitor/node_modules/@revenuecat/purchases-typescript-internal-esm": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal-esm/-/purchases-typescript-internal-esm-14.3.0.tgz",
+			"integrity": "sha512-7mkuBupATfPvBw+skTE/chY6UEux9ZidTbKBOcZ/MgALKJdcww7LgSbChdyoGdQlSJXBFf1zRPzHH+RB7y+LQA==",
+			"license": "MIT"
+		},
+		"node_modules/@revenuecat/purchases-typescript-internal-esm": {
+			"version": "17.25.0",
+			"resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal-esm/-/purchases-typescript-internal-esm-17.25.0.tgz",
+			"integrity": "sha512-KC4BjFaQclXqFafG1Enh7t8GSwdg8p905by7UrHq0WSJmLhOR6yXSj6WDv1iwsFSAZxPPwgozNxt+U6IOFTdCA==",
+			"license": "MIT"
 		},
 		"node_modules/@rollup/plugin-commonjs": {
 			"version": "25.0.7",
@@ -21889,6 +21941,46 @@
 			"resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
 			"integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
 			"requires": {}
+		},
+		"@revenuecat/purchases-capacitor": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/@revenuecat/purchases-capacitor/-/purchases-capacitor-11.3.2.tgz",
+			"integrity": "sha512-3T4/lcAwpbPagrT4DuXvJ+8RewzFmHf3fQJQuhVy+uTQk5HGMHNlXcm2A/UdyHtWqU+/VqWbCClPFYGnpnNXAQ==",
+			"requires": {
+				"@revenuecat/purchases-typescript-internal-esm": "17.25.0"
+			}
+		},
+		"@revenuecat/purchases-capacitor-ui": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/@revenuecat/purchases-capacitor-ui/-/purchases-capacitor-ui-11.3.2.tgz",
+			"integrity": "sha512-WmXukwbRISYlSaMDP+97HVKQD2VDDXL3FzgFEVhNEjxu/Dl/hSx/AXYiQAWuSuHYaxU0dWUZZwgC+XMVjsa1Dg==",
+			"requires": {
+				"@capacitor/core": "^7.0.0",
+				"@revenuecat/purchases-capacitor": "^10.2.4",
+				"@revenuecat/purchases-typescript-internal-esm": "17.25.0"
+			},
+			"dependencies": {
+				"@revenuecat/purchases-capacitor": {
+					"version": "10.4.0",
+					"resolved": "https://registry.npmjs.org/@revenuecat/purchases-capacitor/-/purchases-capacitor-10.4.0.tgz",
+					"integrity": "sha512-205im5Bs1BY8wLt+qaS0O2GTWtSHUMFc3Z8U2QaVx4EN0hHOk9gqx2bNaUEH+cOWTUPlNz9yikdiMUSTjJzwyA==",
+					"requires": {
+						"@revenuecat/purchases-typescript-internal-esm": "14.3.0"
+					},
+					"dependencies": {
+						"@revenuecat/purchases-typescript-internal-esm": {
+							"version": "14.3.0",
+							"resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal-esm/-/purchases-typescript-internal-esm-14.3.0.tgz",
+							"integrity": "sha512-7mkuBupATfPvBw+skTE/chY6UEux9ZidTbKBOcZ/MgALKJdcww7LgSbChdyoGdQlSJXBFf1zRPzHH+RB7y+LQA=="
+						}
+					}
+				}
+			}
+		},
+		"@revenuecat/purchases-typescript-internal-esm": {
+			"version": "17.25.0",
+			"resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal-esm/-/purchases-typescript-internal-esm-17.25.0.tgz",
+			"integrity": "sha512-KC4BjFaQclXqFafG1Enh7t8GSwdg8p905by7UrHq0WSJmLhOR6yXSj6WDv1iwsFSAZxPPwgozNxt+U6IOFTdCA=="
 		},
 		"@rollup/plugin-commonjs": {
 			"version": "25.0.7",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
 		"@google/generative-ai": "^0.24.1",
 		"@lucia-auth/adapter-sqlite": "^2.0.1",
 		"@lucia-auth/oauth": "^3.5.3",
+		"@revenuecat/purchases-capacitor": "^11.3.2",
+		"@revenuecat/purchases-capacitor-ui": "^11.3.2",
 		"@sentry/sveltekit": "^10.42.0",
 		"@stripe/stripe-js": "^4.1.0",
 		"@supabase/ssr": "^0.7.0",

--- a/src/lib/components/PaywallModal.svelte
+++ b/src/lib/components/PaywallModal.svelte
@@ -3,13 +3,47 @@
   import Modal from '$lib/components/Modal.svelte';
   import Checkmark from '$lib/components/Checkmark.svelte';
   import Button from '$lib/components/Button.svelte';
+  import { onMount } from 'svelte';
+  import { invalidateAll } from '$app/navigation';
 
   type Props = {
     isOpen: boolean;
     handleCloseModal: () => void;
+    userId?: string;
   }
 
-  let { isOpen = false, handleCloseModal = () => {} }: Props = $props();
+  let { isOpen = false, handleCloseModal = () => {}, userId = '' }: Props = $props();
+
+  let isNative = $state(false);
+  let isPurchasing = $state(false);
+  let purchaseError = $state<string | null>(null);
+
+  onMount(() => {
+    isNative = !!(window as any).Capacitor?.isNativePlatform?.();
+  });
+
+  async function handleApplePurchase() {
+    if (!userId) return;
+    isPurchasing = true;
+    purchaseError = null;
+    try {
+      const { RevenueCatUI } = await import('@revenuecat/purchases-capacitor-ui');
+      const result = await RevenueCatUI.presentPaywall();
+
+      if (result.paywallResult === 'PURCHASED' || result.paywallResult === 'RESTORED') {
+        // Immediately sync to DB
+        await fetch('/api/verify-apple-purchase', { method: 'POST' });
+        await invalidateAll();
+        handleCloseModal();
+      }
+    } catch (err: any) {
+      if (err?.code !== 'PURCHASE_CANCELLED') {
+        purchaseError = 'Purchase failed. Please try again.';
+      }
+    } finally {
+      isPurchasing = false;
+    }
+  }
 </script>
 
 <Modal isOpen={isOpen} handleCloseModal={handleCloseModal} width="min(90%, 600px)" height="fit-content">
@@ -65,12 +99,27 @@
 
     <!-- Footer / Action -->
     <div class="p-6 pt-0">
+      {#if purchaseError}
+        <p class="text-red-400 text-sm mb-3 text-center">{purchaseError}</p>
+      {/if}
+
+      {#if isNative}
+        <Button
+          type="button"
+          onClick={handleApplePurchase}
+          disabled={isPurchasing}
+          className="!py-3 !text-lg w-full shadow-md"
+        >
+          {isPurchasing ? 'Loading...' : 'Subscribe Now'}
+        </Button>
+      {:else}
         <form method="POST" action="/?/subscribe">
-            <input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-            <Button type="submit" className="!py-3 !text-lg w-full shadow-md">
-                Subscribe Now
-            </Button>
+          <input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
+          <Button type="submit" className="!py-3 !text-lg w-full shadow-md">
+            Subscribe Now
+          </Button>
         </form>
+      {/if}
     </div>
   </div>
 </Modal>

--- a/src/lib/helpers/get-user-has-active-subscription.ts
+++ b/src/lib/helpers/get-user-has-active-subscription.ts
@@ -1,62 +1,58 @@
 import { supabase } from '$lib/supabaseClient';
 import { StripeService } from '$lib/services/stripe.service';
 import { isEmailWhitelisted } from './subscription';
+import { REVENUECAT_API_KEY } from '$env/static/private';
 
-/**
- * Check if a user has an active subscription by querying Stripe directly
- * Use this when you need an authoritative check (e.g., before allowing premium content access)
- * For fast UI checks, use checkUserSubscription() from ./subscription.ts instead
- */
 export const getUserHasActiveSubscription = async (userId: string | null) => {
-  // Fast path for no user
-  if (!userId) {
-    return false;
-  }
+  if (!userId) return false;
 
-  // Fetch user email and subscriber_id to check whitelist and subscription
   const { data: user, error } = await supabase
     .from('user')
-    .select('subscriber_id, email')
+    .select('id, subscriber_id, email, is_subscriber')
     .eq('id', userId)
     .single();
 
   if (error && error.code !== 'PGRST116') {
-    console.error('Error fetching user subscription ID:', error);
+    console.error('Error fetching user subscription:', error);
   }
 
-  // Check if user is whitelisted (using shared whitelist)
-  if (isEmailWhitelisted(user?.email)) {
-    return true;
-  }
+  if (isEmailWhitelisted(user?.email)) return true;
 
-  if (!user || !user.subscriber_id) {
-    return false;
-  }
+  if (!user) return false;
 
-  // Check subscription status directly from Stripe
-  try {
-    const subscription = await StripeService.getSubscription(user.subscriber_id);
-    
-    if (!subscription) {
+  // No subscriber_id — fall back to the DB boolean (covers race between purchase and webhook)
+  if (!user.subscriber_id) return user.is_subscriber ?? false;
+
+  // Stripe subscription IDs always start with "sub_"
+  if (user.subscriber_id.startsWith('sub_')) {
+    try {
+      const subscription = await StripeService.getSubscription(user.subscriber_id);
+      if (!subscription) return false;
+      const activeStatuses = ['active', 'trialing', 'past_due'];
+      if (activeStatuses.includes(subscription.status)) {
+        const now = Math.floor(Date.now() / 1000);
+        return !!(subscription.current_period_end && subscription.current_period_end > now);
+      }
+      return false;
+    } catch {
       return false;
     }
+  }
 
-    // Check if subscription is active
-    // Active statuses: 'active', 'trialing', 'past_due' (past_due might still grant access)
-    // Inactive statuses: 'canceled', 'unpaid', 'incomplete', 'incomplete_expired', 'paused'
-    const activeStatuses = ['active', 'trialing', 'past_due'];
-    if (activeStatuses.includes(subscription.status)) {
-      // Also verify the current period hasn't ended
-      const now = Math.floor(Date.now() / 1000);
-      if (subscription.current_period_end && subscription.current_period_end > now) {
-        return true;
+  // RevenueCat / Apple IAP subscriber
+  try {
+    const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
+      headers: {
+        Authorization: `Bearer ${REVENUECAT_API_KEY}`,
+        'X-Platform': 'ios'
       }
-    }
-
-    return false;
-  } catch (error) {
-    console.error('Error fetching subscription from Stripe:', error);
-    // Fallback to false if Stripe check fails
-    return false;
+    });
+    if (!res.ok) return user.is_subscriber ?? false;
+    const data = await res.json();
+    const entitlement = data?.subscriber?.entitlements?.['Parallel Arabic Premium'];
+    if (!entitlement?.expires_date) return false;
+    return new Date(entitlement.expires_date) > new Date();
+  } catch {
+    return user.is_subscriber ?? false;
   }
 };

--- a/src/lib/helpers/get-user-has-active-subscription.ts
+++ b/src/lib/helpers/get-user-has-active-subscription.ts
@@ -1,7 +1,7 @@
 import { supabase } from '$lib/supabaseClient';
 import { StripeService } from '$lib/services/stripe.service';
 import { isEmailWhitelisted } from './subscription';
-import { REVENUECAT_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
 export const getUserHasActiveSubscription = async (userId: string | null) => {
   if (!userId) return false;
@@ -43,7 +43,7 @@ export const getUserHasActiveSubscription = async (userId: string | null) => {
   try {
     const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
       headers: {
-        Authorization: `Bearer ${REVENUECAT_API_KEY}`,
+        Authorization: `Bearer ${env.REVENUECAT_API_KEY}`,
         'X-Platform': 'ios'
       }
     });

--- a/src/lib/services/revenuecat.service.ts
+++ b/src/lib/services/revenuecat.service.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_REVENUECAT_IOS_API_KEY } from '$env/static/public';
+import { env } from '$env/dynamic/public';
 import type { CustomerInfo, PurchasesPackage } from '@revenuecat/purchases-capacitor';
 
 export const ENTITLEMENT_ID = 'Parallel Arabic Premium';
@@ -11,7 +11,7 @@ export const RevenueCatService = {
     const { Purchases, LOG_LEVEL } = await import('@revenuecat/purchases-capacitor');
     await Purchases.setLogLevel({ level: LOG_LEVEL.WARN });
     await Purchases.configure({
-      apiKey: PUBLIC_REVENUECAT_IOS_API_KEY,
+      apiKey: env.PUBLIC_REVENUECAT_IOS_API_KEY,
       appUserID: userId
     });
     initialized = true;

--- a/src/lib/services/revenuecat.service.ts
+++ b/src/lib/services/revenuecat.service.ts
@@ -1,0 +1,48 @@
+import { PUBLIC_REVENUECAT_IOS_API_KEY } from '$env/static/public';
+import type { CustomerInfo, PurchasesPackage } from '@revenuecat/purchases-capacitor';
+
+export const ENTITLEMENT_ID = 'Parallel Arabic Premium';
+
+let initialized = false;
+
+export const RevenueCatService = {
+  async initialize(userId: string) {
+    if (initialized) return;
+    const { Purchases, LOG_LEVEL } = await import('@revenuecat/purchases-capacitor');
+    await Purchases.setLogLevel({ level: LOG_LEVEL.WARN });
+    await Purchases.configure({
+      apiKey: PUBLIC_REVENUECAT_IOS_API_KEY,
+      appUserID: userId
+    });
+    initialized = true;
+  },
+
+  async getCurrentOffering(): Promise<PurchasesPackage | null> {
+    const { Purchases } = await import('@revenuecat/purchases-capacitor');
+    const { current } = await Purchases.getOfferings();
+    return current?.availablePackages[0] ?? null;
+  },
+
+  async purchasePackage(pkg: PurchasesPackage): Promise<CustomerInfo> {
+    const { Purchases } = await import('@revenuecat/purchases-capacitor');
+    const { customerInfo } = await Purchases.purchasePackage({ aPackage: pkg });
+    return customerInfo;
+  },
+
+  async restorePurchases(): Promise<CustomerInfo> {
+    const { Purchases } = await import('@revenuecat/purchases-capacitor');
+    const { customerInfo } = await Purchases.restorePurchases();
+    return customerInfo;
+  },
+
+  async getCustomerInfo(): Promise<CustomerInfo> {
+    const { Purchases } = await import('@revenuecat/purchases-capacitor');
+    const { customerInfo } = await Purchases.getCustomerInfo();
+    return customerInfo;
+  },
+
+  isEntitlementActive(customerInfo: CustomerInfo): boolean {
+    const entitlement = customerInfo.entitlements.active[ENTITLEMENT_ID];
+    return !!entitlement;
+  }
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -123,6 +123,12 @@
 
 		resumeImportJobIfNeeded().catch(() => {});
 
+		// Initialize RevenueCat in native app when user is logged in
+		if (isNativeApp() && data.user?.id) {
+			const { RevenueCatService } = await import('$lib/services/revenuecat.service');
+			RevenueCatService.initialize(data.user.id).catch(console.error);
+		}
+
 		// Only inject Vercel analytics when NOT in native app
 		if (!isNativeApp()) {
 			injectAnalytics({ mode: dev ? 'development' : 'production' });

--- a/src/routes/api/revenuecat-webhook/+server.ts
+++ b/src/routes/api/revenuecat-webhook/+server.ts
@@ -1,0 +1,78 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
+import { REVENUECAT_WEBHOOK_SECRET } from '$env/static/private';
+import { supabase } from '$lib/supabaseClient';
+
+export const POST: RequestHandler = async ({ request }) => {
+  // Validate shared secret
+  const authHeader = request.headers.get('Authorization') ?? '';
+  const token = authHeader.replace('Bearer ', '');
+  if (REVENUECAT_WEBHOOK_SECRET && token !== REVENUECAT_WEBHOOK_SECRET) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const event = body?.event;
+
+  if (!event) {
+    return json({ error: 'Missing event' }, { status: 400 });
+  }
+
+  const { app_user_id, type, expiration_at_ms, original_transaction_id } = event;
+
+  if (!app_user_id) {
+    return json({ error: 'Missing app_user_id' }, { status: 400 });
+  }
+
+  switch (type) {
+    case 'INITIAL_PURCHASE':
+    case 'RENEWAL':
+    case 'PRODUCT_CHANGE': {
+      const subscriptionEndDate = expiration_at_ms
+        ? Math.floor(expiration_at_ms / 1000)
+        : Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+
+      const { error } = await supabase
+        .from('user')
+        .update({
+          is_subscriber: true,
+          subscriber_id: original_transaction_id ?? null,
+          subscription_end_date: subscriptionEndDate
+        })
+        .eq('id', app_user_id);
+
+      if (error) console.error('[RC webhook] Error updating subscription:', error);
+      break;
+    }
+
+    case 'CANCELLATION':
+    case 'BILLING_ISSUE': {
+      // User cancelled or has billing issues — retain access until expiration_at_ms
+      if (expiration_at_ms) {
+        const { error } = await supabase
+          .from('user')
+          .update({ subscription_end_date: Math.floor(expiration_at_ms / 1000) })
+          .eq('id', app_user_id);
+
+        if (error) console.error('[RC webhook] Error updating expiry on cancellation:', error);
+      }
+      break;
+    }
+
+    case 'EXPIRATION': {
+      const { error } = await supabase
+        .from('user')
+        .update({
+          is_subscriber: false,
+          subscriber_id: null,
+          subscription_end_date: null
+        })
+        .eq('id', app_user_id);
+
+      if (error) console.error('[RC webhook] Error clearing subscription on expiration:', error);
+      break;
+    }
+  }
+
+  return json({ received: true });
+};

--- a/src/routes/api/revenuecat-webhook/+server.ts
+++ b/src/routes/api/revenuecat-webhook/+server.ts
@@ -1,13 +1,13 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { REVENUECAT_WEBHOOK_SECRET } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { supabase } from '$lib/supabaseClient';
 
 export const POST: RequestHandler = async ({ request }) => {
   // Validate shared secret
   const authHeader = request.headers.get('Authorization') ?? '';
   const token = authHeader.replace('Bearer ', '');
-  if (REVENUECAT_WEBHOOK_SECRET && token !== REVENUECAT_WEBHOOK_SECRET) {
+  if (env.REVENUECAT_WEBHOOK_SECRET && token !== env.REVENUECAT_WEBHOOK_SECRET) {
     return json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/routes/api/verify-apple-purchase/+server.ts
+++ b/src/routes/api/verify-apple-purchase/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { REVENUECAT_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { supabase } from '$lib/supabaseClient';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -14,7 +14,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
   try {
     const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
       headers: {
-        Authorization: `Bearer ${REVENUECAT_API_KEY}`,
+        Authorization: `Bearer ${env.REVENUECAT_API_KEY}`,
         'X-Platform': 'ios'
       }
     });

--- a/src/routes/api/verify-apple-purchase/+server.ts
+++ b/src/routes/api/verify-apple-purchase/+server.ts
@@ -1,0 +1,58 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
+import { REVENUECAT_API_KEY } from '$env/static/private';
+import { supabase } from '$lib/supabaseClient';
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+
+  try {
+    const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
+      headers: {
+        Authorization: `Bearer ${REVENUECAT_API_KEY}`,
+        'X-Platform': 'ios'
+      }
+    });
+
+    if (!res.ok) {
+      return json({ error: 'Failed to fetch subscriber info' }, { status: 502 });
+    }
+
+    const data = await res.json();
+    const entitlement = data?.subscriber?.entitlements?.['Parallel Arabic Premium'];
+
+    if (!entitlement) {
+      return json({ active: false });
+    }
+
+    const expiresDate = entitlement.expires_date ? new Date(entitlement.expires_date) : null;
+    const isActive = expiresDate ? expiresDate > new Date() : false;
+
+    if (isActive) {
+      const subscriptions = data?.subscriber?.subscriptions ?? {};
+      const subKey = Object.keys(subscriptions)[0];
+      const transactionId = subscriptions[subKey]?.original_transaction_id ?? subKey ?? null;
+
+      const { error } = await supabase
+        .from('user')
+        .update({
+          is_subscriber: true,
+          subscriber_id: transactionId,
+          subscription_end_date: expiresDate ? Math.floor(expiresDate.getTime() / 1000) : null
+        })
+        .eq('id', userId);
+
+      if (error) console.error('[verify-apple-purchase] DB update error:', error);
+    }
+
+    return json({ active: isActive });
+  } catch (err) {
+    console.error('[verify-apple-purchase] Error:', err);
+    return json({ error: 'Internal error' }, { status: 500 });
+  }
+};

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -1,7 +1,36 @@
-<script>
+<script lang="ts">
 	import Checkmark from '$lib/components/Checkmark.svelte';
   import Button from '$lib/components/Button.svelte';
-  import { PUBLIC_PRICE_ID } from '$env/static/public'
+  import { PUBLIC_PRICE_ID } from '$env/static/public';
+  import { onMount } from 'svelte';
+  import { invalidateAll } from '$app/navigation';
+
+  let isNative = $state(false);
+  let isPurchasing = $state(false);
+  let purchaseError = $state<string | null>(null);
+
+  onMount(() => {
+    isNative = !!(window as any).Capacitor?.isNativePlatform?.();
+  });
+
+  async function handleApplePurchase() {
+    isPurchasing = true;
+    purchaseError = null;
+    try {
+      const { RevenueCatUI } = await import('@revenuecat/purchases-capacitor-ui');
+      const result = await RevenueCatUI.presentPaywall();
+      if (result.paywallResult === 'PURCHASED' || result.paywallResult === 'RESTORED') {
+        await fetch('/api/verify-apple-purchase', { method: 'POST' });
+        await invalidateAll();
+      }
+    } catch (err: any) {
+      if (err?.code !== 'PURCHASE_CANCELLED') {
+        purchaseError = 'Purchase failed. Please try again.';
+      }
+    } finally {
+      isPurchasing = false;
+    }
+  }
 </script>
 
 <div class="min-h-screen bg-tile-300">
@@ -131,12 +160,26 @@
                                 <span>Access to custom built Anki decks for all dialects</span>
                             </li>
                         </ul>
-                         <form method="POST" action="/?/subscribe" class="mt-8">
+                        {#if purchaseError}
+                          <p class="text-red-400 text-sm mt-4 text-center">{purchaseError}</p>
+                        {/if}
+                        {#if isNative}
+                          <Button
+                            type="button"
+                            onClick={handleApplePurchase}
+                            disabled={isPurchasing}
+                            className="!py-3 !text-lg w-full mt-8"
+                          >
+                            {isPurchasing ? 'Loading...' : 'Subscribe Now'}
+                          </Button>
+                        {:else}
+                          <form method="POST" action="/?/subscribe" class="mt-8">
                             <input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
                             <Button type="submit" className="!py-3 !text-lg w-full">
-                            Subscribe Now
+                              Subscribe Now
                             </Button>
-                        </form>
+                          </form>
+                        {/if}
                     </div>
                 </div>
             </div>

--- a/src/routes/profile/+page.server.ts
+++ b/src/routes/profile/+page.server.ts
@@ -5,6 +5,7 @@ import { getUserHasActiveSubscription } from '$lib/helpers/get-user-has-active-s
 import { getStoriesByUser } from '$lib/helpers/story-helpers';
 import { StripeService } from '$lib/services/stripe.service';
 import { computeAchievements } from '$lib/config/achievements';
+import { REVENUECAT_API_KEY } from '$env/static/private';
 
 export const load = async ({ locals, parent }) => {
 	const { session, user } = await parent();
@@ -36,7 +37,15 @@ export const load = async ({ locals, parent }) => {
     console.error('Error fetching user onboarding data:', userError);
   }
 
-  // Fetch subscription details from Stripe if user has a subscriber_id
+  // Determine subscription provider and fetch details
+  const isStripeSubscriber = userData?.subscriber_id?.startsWith('sub_') ?? false;
+  const isAppleSubscriber = !!(userData?.subscriber_id && !isStripeSubscriber);
+  const subscriptionProvider: 'stripe' | 'apple' | null = isStripeSubscriber
+    ? 'stripe'
+    : isAppleSubscriber
+      ? 'apple'
+      : null;
+
   let subscriptionDetails: {
     cancelAtPeriodEnd: boolean;
     currentPeriodEnd: number | null;
@@ -47,7 +56,7 @@ export const load = async ({ locals, parent }) => {
     status: null
   };
 
-  if (userData?.subscriber_id) {
+  if (isStripeSubscriber && userData?.subscriber_id) {
     try {
       const subscription = await StripeService.getSubscription(userData.subscriber_id);
       if (subscription) {
@@ -59,6 +68,29 @@ export const load = async ({ locals, parent }) => {
       }
     } catch (error) {
       console.error('Error fetching subscription from Stripe:', error);
+    }
+  } else if (isAppleSubscriber) {
+    try {
+      const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
+        headers: {
+          Authorization: `Bearer ${REVENUECAT_API_KEY}`,
+          'X-Platform': 'ios'
+        }
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const entitlement = data?.subscriber?.entitlements?.['Parallel Arabic Premium'];
+        if (entitlement?.expires_date) {
+          const expiresUnix = Math.floor(new Date(entitlement.expires_date).getTime() / 1000);
+          subscriptionDetails = {
+            cancelAtPeriodEnd: !!entitlement.unsubscribe_detected_at,
+            currentPeriodEnd: expiresUnix,
+            status: 'active'
+          };
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching subscription from RevenueCat:', error);
     }
   }
 
@@ -179,6 +211,7 @@ export const load = async ({ locals, parent }) => {
     wordStats,
     user, // Include user for stats component
     subscriptionDetails,
+    subscriptionProvider,
     achievements
 	};
 };

--- a/src/routes/profile/+page.server.ts
+++ b/src/routes/profile/+page.server.ts
@@ -5,7 +5,7 @@ import { getUserHasActiveSubscription } from '$lib/helpers/get-user-has-active-s
 import { getStoriesByUser } from '$lib/helpers/story-helpers';
 import { StripeService } from '$lib/services/stripe.service';
 import { computeAchievements } from '$lib/config/achievements';
-import { REVENUECAT_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
 export const load = async ({ locals, parent }) => {
 	const { session, user } = await parent();
@@ -73,7 +73,7 @@ export const load = async ({ locals, parent }) => {
     try {
       const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
         headers: {
-          Authorization: `Bearer ${REVENUECAT_API_KEY}`,
+          Authorization: `Bearer ${env.REVENUECAT_API_KEY}`,
           'X-Platform': 'ios'
         }
       });

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -180,7 +180,16 @@
     showCancelConfirm = false;
     cancelError = null;
   }
-  
+
+  async function openCustomerCenter() {
+    try {
+      const { RevenueCatUI } = await import('@revenuecat/purchases-capacitor-ui');
+      await RevenueCatUI.presentCustomerCenter();
+    } catch (err) {
+      console.error('Failed to open Customer Center:', err);
+    }
+  }
+
   // Format date helper
   function formatDate(timestamp: number | null): string {
     if (!timestamp) return 'Unknown';
@@ -613,7 +622,7 @@
           {#if data.hasActiveSubscription && !WHITELISTED_EMAILS.includes(data.user.email)}
             <div class="p-6 bg-tile-500/20">
               <h3 class="text-base font-bold text-text-300 mb-4 uppercase tracking-wide">Subscription</h3>
-              
+
               <div class="space-y-4">
                 <!-- Subscription Status -->
                 <div class="bg-tile-400 border border-tile-600 rounded-lg p-4">
@@ -627,60 +636,74 @@
                         </p>
                       {:else}
                         <p class="text-sm text-text-200">
-                          Next billing: {formatDate(data.subscriptionDetails?.currentPeriodEnd)}
+                          {data.subscriptionProvider === 'apple' ? 'Expires' : 'Next billing'}: {formatDate(data.subscriptionDetails?.currentPeriodEnd)}
                         </p>
                       {/if}
                     </div>
                   </div>
-                  
-                  {#if cancelError}
-                    <div class="bg-red-500/20 border border-red-400 text-red-300 px-3 py-2 rounded-lg mb-3 text-sm" transition:fade>
-                      {cancelError}
-                    </div>
-                  {/if}
 
-                  {#if cancelSuccess}
-                    <div class="bg-green-500/20 border border-green-400 text-green-700 px-3 py-2 rounded-lg mb-3 text-sm" transition:fade>
-                      {cancelSuccess}
-                    </div>
-                  {/if}
-                  
-                  {#if !data.subscriptionDetails?.cancelAtPeriodEnd}
-                    {#if showCancelConfirm}
-                      <div class="space-y-3 mt-4 p-4 bg-red-900/20 border border-red-800/50 rounded-lg">
-                        <p class="text-yellow-300 text-sm font-medium">⚠️ Are you sure you want to cancel?</p>
-                        <p class="text-text-200 text-xs">You'll retain access to premium features until {formatDate(data.subscriptionDetails?.currentPeriodEnd)}.</p>
-                        <div class="flex gap-2">
-                          <Button 
-                            onClick={cancelSubscription} 
-                            type="button" 
-                            disabled={isCancelling}
-                            className="bg-red-600 hover:bg-red-700 flex-1 text-sm"
-                          >
-                            {isCancelling ? 'Cancelling...' : 'Yes, Cancel Subscription'}
-                          </Button>
-                          <Button 
-                            onClick={cancelCancelSubscription} 
-                            type="button"
-                            disabled={isCancelling}
-                            className="flex-1 text-sm"
-                          >
-                            Keep Subscription
-                          </Button>
-                        </div>
-                      </div>
-                    {:else}
-                      <button 
-                        onclick={cancelSubscription}
-                        class="text-sm text-red-400 hover:text-red-300 underline transition-colors"
-                      >
-                        Cancel subscription
-                      </button>
-                    {/if}
-                  {:else}
+                  {#if data.subscriptionProvider === 'apple'}
+                    <!-- Apple IAP: managed via iOS Settings -->
                     <p class="text-sm text-text-200 mt-2">
-                      Your subscription is set to cancel. You can continue using premium features until your access expires.
+                      Your subscription is managed through the App Store. To cancel, go to <strong class="text-text-300">Settings → Apple ID → Subscriptions</strong> on your iPhone.
                     </p>
+                    <button
+                      onclick={openCustomerCenter}
+                      class="mt-3 text-sm text-blue-400 hover:text-blue-300 underline transition-colors"
+                    >
+                      Manage subscription
+                    </button>
+                  {:else}
+                    <!-- Stripe: existing cancel flow -->
+                    {#if cancelError}
+                      <div class="bg-red-500/20 border border-red-400 text-red-300 px-3 py-2 rounded-lg mb-3 text-sm" transition:fade>
+                        {cancelError}
+                      </div>
+                    {/if}
+
+                    {#if cancelSuccess}
+                      <div class="bg-green-500/20 border border-green-400 text-green-700 px-3 py-2 rounded-lg mb-3 text-sm" transition:fade>
+                        {cancelSuccess}
+                      </div>
+                    {/if}
+
+                    {#if !data.subscriptionDetails?.cancelAtPeriodEnd}
+                      {#if showCancelConfirm}
+                        <div class="space-y-3 mt-4 p-4 bg-red-900/20 border border-red-800/50 rounded-lg">
+                          <p class="text-yellow-300 text-sm font-medium">⚠️ Are you sure you want to cancel?</p>
+                          <p class="text-text-200 text-xs">You'll retain access to premium features until {formatDate(data.subscriptionDetails?.currentPeriodEnd)}.</p>
+                          <div class="flex gap-2">
+                            <Button
+                              onClick={cancelSubscription}
+                              type="button"
+                              disabled={isCancelling}
+                              className="bg-red-600 hover:bg-red-700 flex-1 text-sm"
+                            >
+                              {isCancelling ? 'Cancelling...' : 'Yes, Cancel Subscription'}
+                            </Button>
+                            <Button
+                              onClick={cancelCancelSubscription}
+                              type="button"
+                              disabled={isCancelling}
+                              className="flex-1 text-sm"
+                            >
+                              Keep Subscription
+                            </Button>
+                          </div>
+                        </div>
+                      {:else}
+                        <button
+                          onclick={cancelSubscription}
+                          class="text-sm text-red-400 hover:text-red-300 underline transition-colors"
+                        >
+                          Cancel subscription
+                        </button>
+                      {/if}
+                    {:else}
+                      <p class="text-sm text-text-200 mt-2">
+                        Your subscription is set to cancel. You can continue using premium features until your access expires.
+                      </p>
+                    {/if}
                   {/if}
                 </div>
               </div>

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -1,0 +1,52 @@
+{
+  "name": "Parallel Arabic",
+  "short_name": "Parallel Arabic",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#cfdce2",
+  "theme_color": "#005580",
+  "icons": [
+    {
+      "src": "../icons/icon-48.webp",
+      "type": "image/png",
+      "sizes": "48x48",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "../icons/icon-72.webp",
+      "type": "image/png",
+      "sizes": "72x72",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "../icons/icon-96.webp",
+      "type": "image/png",
+      "sizes": "96x96",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "../icons/icon-128.webp",
+      "type": "image/png",
+      "sizes": "128x128",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "../icons/icon-192.webp",
+      "type": "image/png",
+      "sizes": "192x192",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "../icons/icon-256.webp",
+      "type": "image/png",
+      "sizes": "256x256",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "../icons/icon-512.webp",
+      "type": "image/png",
+      "sizes": "512x512",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds RevenueCat (`@revenuecat/purchases-capacitor` v11) as the iOS in-app purchase provider to comply with App Store Guideline 3.1.1
- On iOS native: `PaywallModal` and pricing page present the native RevenueCat paywall instead of the Stripe checkout form
- On web: Stripe flow is completely unchanged — zero regression risk for existing subscribers

## What changed
- **New:** `src/lib/services/revenuecat.service.ts` — RC SDK wrapper (initialize, purchase, restore)
- **New:** `src/routes/api/revenuecat-webhook/+server.ts` — handles INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION events
- **New:** `src/routes/api/verify-apple-purchase/+server.ts` — immediate post-purchase DB sync before webhook fires
- **Modified:** `getUserHasActiveSubscription` — detects Stripe (`sub_` prefix) vs Apple subscribers, calls RC REST API for Apple
- **Modified:** `PaywallModal` + `pricing/+page` — platform-aware subscribe buttons
- **Modified:** `profile/+page` — shows App Store management UI for Apple subscribers, Customer Center button
- **Modified:** `+layout.svelte` — initializes RC SDK on app mount when on native iOS and logged in
- iOS minimum deployment target bumped to 15.0 (required by RC UI package)

## Test plan
- [ ] Web: Stripe subscribe flow works unchanged on `/pricing`
- [ ] Web: Existing Stripe subscribers see cancel button on profile (not Apple management UI)
- [ ] iOS: Hitting any paywall shows native RC paywall sheet (not web modal)
- [ ] iOS: Sandbox purchase completes → `is_subscriber` flips in DB
- [ ] iOS: Profile shows "Managed through App Store" with no cancel button
- [ ] RC webhook: EXPIRATION event clears subscription correctly

## Env vars required in Vercel
- `REVENUECAT_API_KEY`
- `REVENUECAT_WEBHOOK_SECRET`
- `PUBLIC_REVENUECAT_IOS_API_KEY`
- `PUBLIC_REVENUECAT_PRODUCT_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)