### PR TITLE
Fix RevenueCat build and paywall issues

### DIFF
--- a/src/lib/components/PaywallModal.svelte
+++ b/src/lib/components/PaywallModal.svelte
@@ -9,10 +9,9 @@
   type Props = {
     isOpen: boolean;
     handleCloseModal: () => void;
-    userId?: string;
   }
 
-  let { isOpen = false, handleCloseModal = () => {}, userId = '' }: Props = $props();
+  let { isOpen = false, handleCloseModal = () => {} }: Props = $props();
 
   let isNative = $state(false);
   let isPurchasing = $state(false);
@@ -23,7 +22,6 @@
   });
 
   async function handleApplePurchase() {
-    if (!userId) return;
     isPurchasing = true;
     purchaseError = null;
     try {


### PR DESCRIPTION
## Summary
- Switch RC env vars from `$env/static` to `$env/dynamic` so the build doesn't fail when vars aren't present at build time
- Fix PaywallModal: remove `userId` guard that was silently blocking the Apple purchase flow on iOS (userId was never passed by any caller)

## Changes
- `src/lib/services/revenuecat.service.ts` — use `$env/dynamic/public`
- `src/lib/helpers/get-user-has-active-subscription.ts` — use `$env/dynamic/private`
- `src/routes/api/verify-apple-purchase/+server.ts` — use `$env/dynamic/private`
- `src/routes/api/revenuecat-webhook/+server.ts` — use `$env/dynamic/private`
- `src/routes/profile/+page.server.ts` — use `$env/dynamic/private`
- `src/lib/components/PaywallModal.svelte` — remove dead userId prop and guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)