### PR TITLE
Replace inline Stripe forms with platform-aware SubscribeButton

### DIFF
--- a/src/lib/components/PaywallModal.svelte
+++ b/src/lib/components/PaywallModal.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-  import { PUBLIC_PRICE_ID } from '$env/static/public'
   import Modal from '$lib/components/Modal.svelte';
   import Checkmark from '$lib/components/Checkmark.svelte';
-  import Button from '$lib/components/Button.svelte';
-  import { onMount } from 'svelte';
-  import { invalidateAll } from '$app/navigation';
+  import SubscribeButton from '$lib/components/SubscribeButton.svelte';
 
   type Props = {
     isOpen: boolean;
@@ -12,36 +9,6 @@
   }
 
   let { isOpen = false, handleCloseModal = () => {} }: Props = $props();
-
-  let isNative = $state(false);
-  let isPurchasing = $state(false);
-  let purchaseError = $state<string | null>(null);
-
-  onMount(() => {
-    isNative = !!(window as any).Capacitor?.isNativePlatform?.();
-  });
-
-  async function handleApplePurchase() {
-    isPurchasing = true;
-    purchaseError = null;
-    try {
-      const { RevenueCatUI } = await import('@revenuecat/purchases-capacitor-ui');
-      const result = await RevenueCatUI.presentPaywall();
-
-      if (result.paywallResult === 'PURCHASED' || result.paywallResult === 'RESTORED') {
-        // Immediately sync to DB
-        await fetch('/api/verify-apple-purchase', { method: 'POST' });
-        await invalidateAll();
-        handleCloseModal();
-      }
-    } catch (err: any) {
-      if (err?.code !== 'PURCHASE_CANCELLED') {
-        purchaseError = `[DEBUG] code=${err?.code} message=${err?.message} full=${JSON.stringify(err)}`;
-      }
-    } finally {
-      isPurchasing = false;
-    }
-  }
 </script>
 
 <Modal isOpen={isOpen} handleCloseModal={handleCloseModal} width="min(90%, 600px)" height="fit-content">
@@ -97,27 +64,7 @@
 
     <!-- Footer / Action -->
     <div class="p-6 pt-0">
-      {#if purchaseError}
-        <p class="text-red-400 text-sm mb-3 text-center">{purchaseError}</p>
-      {/if}
-
-      {#if isNative}
-        <Button
-          type="button"
-          onClick={handleApplePurchase}
-          disabled={isPurchasing}
-          className="!py-3 !text-lg w-full shadow-md"
-        >
-          {isPurchasing ? 'Loading...' : 'Subscribe Now'}
-        </Button>
-      {:else}
-        <form method="POST" action="/?/subscribe">
-          <input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-          <Button type="submit" className="!py-3 !text-lg w-full shadow-md">
-            Subscribe Now
-          </Button>
-        </form>
-      {/if}
+      <SubscribeButton className="!py-3 !text-lg w-full shadow-md" />
     </div>
   </div>
 </Modal>

--- a/src/lib/components/SubscribeButton.svelte
+++ b/src/lib/components/SubscribeButton.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { PUBLIC_PRICE_ID } from '$env/static/public';
+  import Button from '$lib/components/Button.svelte';
+  import { onMount } from 'svelte';
+  import { invalidateAll } from '$app/navigation';
+
+  type Props = {
+    label?: string;
+    className?: string;
+    nativeClass?: string;
+  }
+
+  let { label = 'Subscribe Now', className = '', nativeClass = '' }: Props = $props();
+
+  let isNative = $state(false);
+  let isPurchasing = $state(false);
+  let purchaseError = $state<string | null>(null);
+
+  onMount(() => {
+    isNative = !!(window as any).Capacitor?.isNativePlatform?.();
+  });
+
+  async function handleApplePurchase() {
+    isPurchasing = true;
+    purchaseError = null;
+    try {
+      const { RevenueCatUI } = await import('@revenuecat/purchases-capacitor-ui');
+      const result = await RevenueCatUI.presentPaywall();
+      if (result.paywallResult === 'PURCHASED' || result.paywallResult === 'RESTORED') {
+        await fetch('/api/verify-apple-purchase', { method: 'POST' });
+        await invalidateAll();
+      }
+    } catch (err: any) {
+      if (err?.code !== 'PURCHASE_CANCELLED') {
+        purchaseError = 'Purchase failed. Please try again.';
+      }
+    } finally {
+      isPurchasing = false;
+    }
+  }
+</script>
+
+{#if purchaseError}
+  <p class="text-red-400 text-sm mb-2 text-center">{purchaseError}</p>
+{/if}
+
+{#if isNative}
+  <Button
+    type="button"
+    onClick={handleApplePurchase}
+    disabled={isPurchasing}
+    className={className}
+  >
+    {isPurchasing ? 'Loading...' : label}
+  </Button>
+{:else}
+  <form method="POST" action="/?/subscribe">
+    <input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
+    <Button type="submit" className={className}>
+      {label}
+    </Button>
+  </form>
+{/if}

--- a/src/routes/darija/vocab/[section]/+page.svelte
+++ b/src/routes/darija/vocab/[section]/+page.svelte
@@ -3,6 +3,7 @@
   import VocabQuizBlock from '$lib/components/dialect-shared/vocab/VocabQuizBlock.svelte';
 	import { darijaSections } from '$lib/constants/darija-sections';
 	import { PUBLIC_PRICE_ID } from '$env/static/public';
+	import SubscribeButton from '$lib/components/SubscribeButton.svelte';
   import { updateUrl } from '$lib/helpers/update-url';
 	interface Props {
 		data: any;
@@ -74,10 +75,7 @@
 		<div class="border border-tile-600 bg-tile-300 py-4 px-3 text-center">
 			<h1 class="text-2xl font-bold text-text-300">You are not subscribed.</h1>
 			<p class="mt-2 text-xl text-text-200">To continue practicing, please subscribe.</p>
-			<form method="POST" action="/?/subscribe" class="mx-auto mt-4 w-fit">
-				<input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-				<Button type="submit">Subscribe</Button>
-			</form>
+			<SubscribeButton className="mx-auto mt-4" />
 		</div>
 	</div>
 {:else}

--- a/src/routes/darija/write/[section]/+page.svelte
+++ b/src/routes/darija/write/[section]/+page.svelte
@@ -3,6 +3,7 @@
 	import Button from '$lib/components/Button.svelte';
 	import { darijaSections } from '$lib/constants/darija-sections';
 	import { PUBLIC_PRICE_ID } from '$env/static/public';
+	import SubscribeButton from '$lib/components/SubscribeButton.svelte';
   import { updateUrl } from '$lib/helpers/update-url';
   let { data } = $props();
 
@@ -65,10 +66,7 @@
 		<div class="border border-tile-600 bg-tile-300 py-4 px-3 text-center">
 			<h1 class="text-2xl font-bold text-text-300">You are not subscribed.</h1>
 			<p class="mt-2 text-xl text-text-200">To continue practicing, please subscribe.</p>
-			<form method="POST" action="/?/subscribe" class="mx-auto mt-4 w-fit">
-				<input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-				<Button type="submit">Subscribe</Button>
-			</form>
+			<SubscribeButton className="mx-auto mt-4" />
 		</div>
 	</div>
 {:else}

--- a/src/routes/egyptian-arabic/stories/[story]/+page.svelte
+++ b/src/routes/egyptian-arabic/stories/[story]/+page.svelte
@@ -6,6 +6,7 @@
 	import { getWordObjectToSave } from '$lib/helpers/get-word-object-to-save';
 	import Checkmark from '$lib/components/Checkmark.svelte';
 	import { PUBLIC_PRICE_ID } from '$env/static/public';
+	import SubscribeButton from '$lib/components/SubscribeButton.svelte';
 	import Audio from '$lib/components/Audio.svelte';
 	import AudioButton from '$lib/components/AudioButton.svelte';
 	import ArabicWordDisplay from '$lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte';
@@ -194,10 +195,7 @@ $inspect(activeWordObj)
 	<div class="mx-4 mb-6 mt-12 border border-tile-600 bg-tile-300 py-4 text-center sm:mx-36">
 		<h1 class="text-2xl font-bold text-text-300">You are not subscribed.</h1>
 		<p class="mt-2 text-xl text-text-200">To continue practicing, please subscribe.</p>
-		<form method="POST" action="/?/subscribe" class="mx-auto mt-4 w-fit">
-			<input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-			<Button type="submit">Subscribe</Button>
-		</form>
+		<SubscribeButton className="mx-auto mt-4" />
 	</div>
 {:else}
 	<DefinitionModal {activeWordObj} {isModalOpen} {closeModal} dialect="egyptian-arabic"></DefinitionModal>

--- a/src/routes/generated_story/[id]/+page.svelte
+++ b/src/routes/generated_story/[id]/+page.svelte
@@ -13,6 +13,8 @@
 	import { Mode, type KeyWord } from '$lib/types/index';
 	import type { PageData } from './$types';
   import AudioButton from '$lib/components/AudioButton.svelte';
+  import PaywallModal from '$lib/components/PaywallModal.svelte';
+  let isPaywallOpen = $state(false);
   import ArabicWordDisplay from '$lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte';
   import StoryAudioButton from '$lib/components/StoryAudioButton.svelte';
   import InlineAudioButton from '$lib/components/InlineAudioButton.svelte';
@@ -673,9 +675,9 @@
         <p class="mb-6 text-text-200">
           This story has {sentences.length} sentences. Subscribe to read the full story, earn XP, and track your progress.
         </p>
-        <a href="/pricing/checkout" class="rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-blue-700">
+        <button onclick={() => isPaywallOpen = true} class="rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-blue-700">
           Subscribe
-        </a>
+        </button>
       {/if}
     </div>
   {/if}
@@ -1015,3 +1017,5 @@
     </div>
   </section>
 {/if}
+
+<PaywallModal isOpen={isPaywallOpen} handleCloseModal={() => isPaywallOpen = false} />

--- a/src/routes/levantine/vocab/[section]/+page.svelte
+++ b/src/routes/levantine/vocab/[section]/+page.svelte
@@ -3,6 +3,7 @@
   import VocabQuizBlock from '$lib/components/dialect-shared/vocab/VocabQuizBlock.svelte';
 	import { levantineSections } from '$lib/constants/levantine-sections';
 	import { PUBLIC_PRICE_ID } from '$env/static/public';
+	import SubscribeButton from '$lib/components/SubscribeButton.svelte';
   import { updateUrl } from '$lib/helpers/update-url';
 	interface Props {
 		data: any;
@@ -74,10 +75,7 @@
 		<div class="border border-tile-600 bg-tile-300 py-4 px-3 text-center">
 			<h1 class="text-2xl font-bold text-text-300">You are not subscribed.</h1>
 			<p class="mt-2 text-xl text-text-200">To continue practicing, please subscribe.</p>
-			<form method="POST" action="/?/subscribe" class="mx-auto mt-4 w-fit">
-				<input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-				<Button type="submit">Subscribe</Button>
-			</form>
+			<SubscribeButton className="mx-auto mt-4" />
 		</div>
 	</div>
 {:else}

--- a/src/routes/levantine/write/[section]/+page.svelte
+++ b/src/routes/levantine/write/[section]/+page.svelte
@@ -3,6 +3,7 @@
 	import Button from '$lib/components/Button.svelte';
 	import { levantineSections } from '$lib/constants/levantine-sections';
 	import { PUBLIC_PRICE_ID } from '$env/static/public';
+	import SubscribeButton from '$lib/components/SubscribeButton.svelte';
   import { updateUrl } from '$lib/helpers/update-url';
   let { data } = $props();
 
@@ -65,10 +66,7 @@
 		<div class="border border-tile-600 bg-tile-300 py-4 px-3 text-center">
 			<h1 class="text-2xl font-bold text-text-300">You are not subscribed.</h1>
 			<p class="mt-2 text-xl text-text-200">To continue practicing, please subscribe.</p>
-			<form method="POST" action="/?/subscribe" class="mx-auto mt-4 w-fit">
-				<input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-				<Button type="submit">Subscribe</Button>
-			</form>
+			<SubscribeButton className="mx-auto mt-4" />
 		</div>
 	</div>
 {:else}

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -1,36 +1,6 @@
 <script lang="ts">
 	import Checkmark from '$lib/components/Checkmark.svelte';
-  import Button from '$lib/components/Button.svelte';
-  import { PUBLIC_PRICE_ID } from '$env/static/public';
-  import { onMount } from 'svelte';
-  import { invalidateAll } from '$app/navigation';
-
-  let isNative = $state(false);
-  let isPurchasing = $state(false);
-  let purchaseError = $state<string | null>(null);
-
-  onMount(() => {
-    isNative = !!(window as any).Capacitor?.isNativePlatform?.();
-  });
-
-  async function handleApplePurchase() {
-    isPurchasing = true;
-    purchaseError = null;
-    try {
-      const { RevenueCatUI } = await import('@revenuecat/purchases-capacitor-ui');
-      const result = await RevenueCatUI.presentPaywall();
-      if (result.paywallResult === 'PURCHASED' || result.paywallResult === 'RESTORED') {
-        await fetch('/api/verify-apple-purchase', { method: 'POST' });
-        await invalidateAll();
-      }
-    } catch (err: any) {
-      if (err?.code !== 'PURCHASE_CANCELLED') {
-        purchaseError = 'Purchase failed. Please try again.';
-      }
-    } finally {
-      isPurchasing = false;
-    }
-  }
+  import SubscribeButton from '$lib/components/SubscribeButton.svelte';
 </script>
 
 <div class="min-h-screen bg-tile-300">
@@ -160,26 +130,9 @@
                                 <span>Access to custom built Anki decks for all dialects</span>
                             </li>
                         </ul>
-                        {#if purchaseError}
-                          <p class="text-red-400 text-sm mt-4 text-center">{purchaseError}</p>
-                        {/if}
-                        {#if isNative}
-                          <Button
-                            type="button"
-                            onClick={handleApplePurchase}
-                            disabled={isPurchasing}
-                            className="!py-3 !text-lg w-full mt-8"
-                          >
-                            {isPurchasing ? 'Loading...' : 'Subscribe Now'}
-                          </Button>
-                        {:else}
-                          <form method="POST" action="/?/subscribe" class="mt-8">
-                            <input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-                            <Button type="submit" className="!py-3 !text-lg w-full">
-                              Subscribe Now
-                            </Button>
-                          </form>
-                        {/if}
+                        <div class="mt-8">
+                          <SubscribeButton className="!py-3 !text-lg w-full" />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -11,6 +11,7 @@
   import { LEVEL_TIERS } from '$lib/helpers/xp-levels';
   import AlphabetCycle from '$lib/components/AlphabetCycle.svelte';
   import { PUBLIC_PRICE_ID } from '$env/static/public';
+  import SubscribeButton from '$lib/components/SubscribeButton.svelte';
   import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
   import { fetchUserReviewWords } from '$lib/helpers/fetch-review-words';
 
@@ -975,12 +976,9 @@
           You've completed {totalReviewCount} word review{totalReviewCount !== 1 ? 's' : ''}. 
           Subscribe to continue using spaced repetition and unlock unlimited reviews!
         </p>
-        <form method="POST" action="/?/subscribe" class="flex justify-center">
-          <input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-          <Button type="submit" className="!bg-yellow-600 !hover:bg-yellow-700 !border-yellow-700 !text-white !text-lg !px-8 !py-3">
-            Subscribe Now
-          </Button>
-        </form>
+        <div class="flex justify-center">
+          <SubscribeButton className="!bg-yellow-600 !hover:bg-yellow-700 !border-yellow-700 !text-white !text-lg !px-8 !py-3" />
+        </div>
       </div>
     {/if}
 

--- a/src/routes/sentences/+page.svelte
+++ b/src/routes/sentences/+page.svelte
@@ -5,6 +5,7 @@
 	import SentenceQuiz from '$lib/components/dialect-shared/sentences/SentenceQuiz.svelte';
 	import { currentDialect } from '$lib/store/store';
 	import { PUBLIC_PRICE_ID } from '$env/static/public';
+	import SubscribeButton from '$lib/components/SubscribeButton.svelte';
 	import { goto } from '$app/navigation';
 	import { updateUrl } from '$lib/helpers/update-url';
 	import AlphabetCycle from '$lib/components/AlphabetCycle.svelte';
@@ -375,10 +376,7 @@
 	<div class="mx-4 mb-6 mt-12 border border-tile-600 bg-tile-300 py-8 text-center sm:mx-auto max-w-2xl rounded-xl shadow-lg">
 		<h1 class="text-2xl font-bold text-text-300">You have reached your limit of 5 sentences.</h1>
 		<p class="mt-2 text-xl text-text-200">To continue practicing, please subscribe.</p>
-		<form method="POST" action="/?/subscribe" class="mx-auto mt-6 w-fit">
-			<input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-			<Button type="submit">Subscribe</Button>
-		</form>
+		<SubscribeButton className="mx-auto mt-6" />
 	</div>
 {/if}
 

--- a/src/routes/speak/+page.svelte
+++ b/src/routes/speak/+page.svelte
@@ -3,6 +3,7 @@
 	import RadioButton from '$lib/components/RadioButton.svelte';
 	import { currentDialect } from '$lib/store/store';
 	import { PUBLIC_PRICE_ID } from '$env/static/public';
+	import SubscribeButton from '$lib/components/SubscribeButton.svelte';
 	import { goto } from '$app/navigation';
 	import { updateUrl } from '$lib/helpers/update-url';
 	import SpeakSentence from '$lib/components/dialect-shared/speak/SpeakSentence.svelte';
@@ -356,12 +357,7 @@
 					<p class="text-lg text-text-200 mb-8 leading-relaxed">
 						You've practiced 5 sentences today. Subscribe to unlock unlimited speaking practice and accelerate your Arabic learning.
 					</p>
-					<form method="POST" action="/?/subscribe">
-						<input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-						<button type="submit" class="px-8 py-4 text-lg font-semibold bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-all duration-300 shadow-lg hover:shadow-xl">
-							Subscribe Now →
-						</button>
-					</form>
+					<SubscribeButton label="Subscribe Now →" className="!bg-emerald-600 !hover:bg-emerald-700 !border-emerald-700 !text-lg !px-8 !py-4" />
 				</div>
 			</div>
 		</div>

--- a/src/routes/stories/[story]/+page.svelte
+++ b/src/routes/stories/[story]/+page.svelte
@@ -6,6 +6,7 @@
 	import { getWordObjectToSave } from '$lib/helpers/get-word-object-to-save';
 	import Checkmark from '$lib/components/Checkmark.svelte';
 	import { PUBLIC_PRICE_ID } from '$env/static/public';
+	import SubscribeButton from '$lib/components/SubscribeButton.svelte';
 	import Audio from '$lib/components/Audio.svelte';
 	import AudioButton from '$lib/components/AudioButton.svelte';
 	import ArabicWordDisplay from '$lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte';
@@ -192,10 +193,7 @@
 	<div class="mx-4 mb-6 mt-12 border border-tile-600 bg-tile-300 py-4 text-center sm:mx-36">
 		<h1 class="text-2xl font-bold text-text-300">You are not subscribed.</h1>
 		<p class="mt-2 text-xl text-text-200">To continue practicing, please subscribe.</p>
-		<form method="POST" action="/?/subscribe" class="mx-auto mt-4 w-fit">
-			<input type="hidden" name="price_id" value={PUBLIC_PRICE_ID} />
-			<Button type="submit">Subscribe</Button>
-		</form>
+		<SubscribeButton className="mx-auto mt-4" />
 	</div>
 {:else}
 	<DefinitionModal {activeWordObj} {isModalOpen} {closeModal} dialect="egyptian-arabic"></DefinitionModal>


### PR DESCRIPTION
## Summary
- Creates `SubscribeButton.svelte` — a single reusable component that shows the RevenueCat native paywall on iOS and the Stripe form on web
- Replaces all 10 inline `<form action="/?/subscribe">` forms and the `/pricing/checkout` link across the app
- `PaywallModal` now uses `SubscribeButton` internally — purchase logic lives in one place

## Files changed
- **New:** `src/lib/components/SubscribeButton.svelte`
- **Updated:** `PaywallModal.svelte`, `pricing/+page.svelte`, `stories/[story]`, `egyptian-arabic/stories/[story]`, `generated_story/[id]`, `speak`, `sentences`, `review`, `darija/write/[section]`, `darija/vocab/[section]`, `levantine/write/[section]`, `levantine/vocab/[section]`

## Test plan
- [ ] Web: Subscribe button in stories/speak/sentences/review submits Stripe form as before
- [ ] iOS TestFlight: Subscribe button triggers RevenueCat native paywall (no extra modal click needed)
- [ ] No remaining inline `/?/subscribe` forms outside of `SubscribeButton` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)