### PR TITLE
Add account deletion (App Store Guideline 5.1.1v)

### DIFF
--- a/src/routes/api/delete-account/+server.ts
+++ b/src/routes/api/delete-account/+server.ts
@@ -1,0 +1,53 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
+import { createClient } from '@supabase/supabase-js';
+import { PUBLIC_SUPABASE_URL } from '$env/static/public';
+import { env } from '$env/dynamic/private';
+import { StripeService } from '$lib/services/stripe.service';
+
+export const POST: RequestHandler = async ({ locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabaseAuthId = session.user.id;
+  const adminSupabase = createClient(PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY ?? '');
+
+  // Fetch user record
+  const { data: userData, error: fetchError } = await adminSupabase
+    .from('user')
+    .select('id, subscriber_id')
+    .eq('supabase_auth_id', supabaseAuthId)
+    .single();
+
+  if (fetchError && fetchError.code !== 'PGRST116') {
+    console.error('[delete-account] Error fetching user:', fetchError);
+  }
+
+  // Cancel Stripe subscription if active
+  if (userData?.subscriber_id?.startsWith('sub_')) {
+    try {
+      await StripeService.cancel(userData.subscriber_id);
+    } catch (err) {
+      console.error('[delete-account] Error cancelling Stripe subscription:', err);
+    }
+  }
+
+  if (userData?.id) {
+    // Delete saved words
+    await adminSupabase.from('saved_word').delete().eq('user_id', userData.id);
+
+    // Delete user record
+    await adminSupabase.from('user').delete().eq('id', userData.id);
+  }
+
+  // Delete Supabase auth user
+  const { error: authDeleteError } = await adminSupabase.auth.admin.deleteUser(supabaseAuthId);
+  if (authDeleteError) {
+    console.error('[delete-account] Error deleting auth user:', authDeleteError);
+    return json({ error: 'Failed to delete account' }, { status: 500 });
+  }
+
+  return json({ success: true });
+};

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -137,6 +137,32 @@
     }
   }
   
+  let showDeleteConfirm = $state(false);
+  let isDeleting = $state(false);
+  let deleteError = $state<string | null>(null);
+
+  async function handleDeleteAccount() {
+    if (!showDeleteConfirm) {
+      showDeleteConfirm = true;
+      return;
+    }
+    isDeleting = true;
+    deleteError = null;
+    try {
+      const res = await fetch('/api/delete-account', { method: 'POST' });
+      if (!res.ok) {
+        const data = await res.json();
+        deleteError = data.error ?? 'Failed to delete account.';
+        isDeleting = false;
+        return;
+      }
+      await goto('/');
+    } catch {
+      deleteError = 'Something went wrong. Please try again.';
+      isDeleting = false;
+    }
+  }
+
   async function cancelSubscription() {
     if (!showCancelConfirm) {
       showCancelConfirm = true;
@@ -608,13 +634,50 @@
                 </p>
               {/if}
               </div>
-              <Button 
+              <Button
                 type="button"
                 onClick={handleLogout}
                 className="bg-red-600 hover:bg-red-700 border-red-700"
               >
                 Sign Out
               </Button>
+            </div>
+
+            <!-- Delete Account -->
+            <div class="mt-6 pt-6 border-t border-tile-600">
+              {#if deleteError}
+                <p class="text-red-400 text-sm mb-3">{deleteError}</p>
+              {/if}
+              {#if showDeleteConfirm}
+                <div class="bg-red-900/20 border border-red-800/50 rounded-lg p-4 space-y-3">
+                  <p class="text-red-400 text-sm font-medium">This will permanently delete your account and all your data. This cannot be undone.</p>
+                  <div class="flex gap-2">
+                    <Button
+                      type="button"
+                      onClick={handleDeleteAccount}
+                      disabled={isDeleting}
+                      className="bg-red-600 hover:bg-red-700 border-red-700 text-sm flex-1"
+                    >
+                      {isDeleting ? 'Deleting...' : 'Yes, Delete My Account'}
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={() => { showDeleteConfirm = false; deleteError = null; }}
+                      disabled={isDeleting}
+                      className="text-sm flex-1"
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              {:else}
+                <button
+                  onclick={handleDeleteAccount}
+                  class="text-sm text-red-400 hover:text-red-300 underline transition-colors"
+                >
+                  Delete account
+                </button>
+              {/if}
             </div>
           </div>
           


### PR DESCRIPTION
## Summary
Implements account deletion as required by App Store Review Guideline 5.1.1(v).

## What it does
- **`/api/delete-account`** (new): cancels any active Stripe subscription, deletes `saved_word` rows, deletes the `user` row, then deletes the Supabase auth user via admin API
- **Profile page**: adds a "Delete account" link below Sign Out with a two-step confirmation warning before executing

## Test plan
- [ ] Sign in → Profile → tap "Delete account" → confirm warning appears
- [ ] Confirm deletion → account gone, redirected to home
- [ ] Verify user row deleted from Supabase
- [ ] Verify Supabase auth user deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)