### PR TITLE
Add Sign in with Apple (App Store Guideline 4.8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@11labs/client": "^0.0.1",
+				"@capacitor-community/apple-sign-in": "^7.1.0",
 				"@capacitor/android": "^7.4.4",
 				"@capacitor/app": "^7.1.0",
 				"@capacitor/browser": "^7.0.2",
@@ -1725,6 +1726,19 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@capacitor-community/apple-sign-in": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@capacitor-community/apple-sign-in/-/apple-sign-in-7.1.0.tgz",
+			"integrity": "sha512-df7cA7vfvvvilTtpJKeVvxO31W+py5t3HK9233GBD5MvgAgtGvCqeQ3pI0noNkVsKPF9B1g/po8Mph6s4bVSmw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/scriptjs": "0.0.2",
+				"scriptjs": "^2.5.9"
+			},
+			"peerDependencies": {
+				"@capacitor/core": ">=7.0.0"
 			}
 		},
 		"node_modules/@capacitor/android": {
@@ -6701,6 +6715,12 @@
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"dev": true
+		},
+		"node_modules/@types/scriptjs": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@types/scriptjs/-/scriptjs-0.0.2.tgz",
+			"integrity": "sha512-GFrUgzGYfNX3VWZwMyzr0JrBwzLv5Kes4BQBvo6hXdRy14/GBbpCiVwwB7v1o2xIEvFf+9GyznmYhuesQQjSag==",
+			"license": "MIT"
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.6",
@@ -16146,6 +16166,12 @@
 			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
 			"license": "ISC"
 		},
+		"node_modules/scriptjs": {
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
+			"integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==",
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "7.6.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -20330,6 +20356,15 @@
 				"@babel/helper-validator-identifier": "^7.28.5"
 			}
 		},
+		"@capacitor-community/apple-sign-in": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@capacitor-community/apple-sign-in/-/apple-sign-in-7.1.0.tgz",
+			"integrity": "sha512-df7cA7vfvvvilTtpJKeVvxO31W+py5t3HK9233GBD5MvgAgtGvCqeQ3pI0noNkVsKPF9B1g/po8Mph6s4bVSmw==",
+			"requires": {
+				"@types/scriptjs": "0.0.2",
+				"scriptjs": "^2.5.9"
+			}
+		},
 		"@capacitor/android": {
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@capacitor/android/-/android-7.4.4.tgz",
@@ -23532,6 +23567,11 @@
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"dev": true
+		},
+		"@types/scriptjs": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@types/scriptjs/-/scriptjs-0.0.2.tgz",
+			"integrity": "sha512-GFrUgzGYfNX3VWZwMyzr0JrBwzLv5Kes4BQBvo6hXdRy14/GBbpCiVwwB7v1o2xIEvFf+9GyznmYhuesQQjSag=="
 		},
 		"@types/semver": {
 			"version": "7.5.6",
@@ -29879,6 +29919,11 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
 			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+		},
+		"scriptjs": {
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
+			"integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg=="
 		},
 		"semver": {
 			"version": "7.6.3",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 	"type": "module",
 	"dependencies": {
 		"@11labs/client": "^0.0.1",
+		"@capacitor-community/apple-sign-in": "^7.1.0",
 		"@capacitor/android": "^7.4.4",
 		"@capacitor/app": "^7.1.0",
 		"@capacitor/browser": "^7.0.2",

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -17,6 +17,56 @@
   let { supabase } = $derived(data);
 
   let appUrlListener: { remove: () => void } | null = null;
+  let appleLoading = $state(false);
+
+  async function handleAppleLogin() {
+    appleLoading = true;
+    const isNative = !!(window as any).Capacitor?.isNativePlatform?.();
+
+    try {
+      if (isNative) {
+        const { SignInWithApple } = await import('@capacitor-community/apple-sign-in');
+        const result = await SignInWithApple.authorize({
+          clientId: 'com.parallelarabic.app',
+          redirectURI: 'com.parallelarabic.app://auth/callback',
+          scopes: 'email name',
+        });
+
+        const { identityToken, givenName, familyName } = result.response;
+        if (!identityToken) throw new Error('No identity token');
+
+        const { error } = await supabase.auth.signInWithIdToken({
+          provider: 'apple',
+          token: identityToken,
+        });
+
+        if (error) throw error;
+
+        // Save name if provided (Apple only sends on first sign-in)
+        if (givenName || familyName) {
+          await supabase.auth.updateUser({
+            data: { full_name: `${givenName ?? ''} ${familyName ?? ''}`.trim() }
+          });
+        }
+
+        await fetch('/api/auth/sync', { method: 'POST' });
+        goto('/');
+      } else {
+        // Web: OAuth redirect
+        const { data: oauthData, error: authError } = await supabase.auth.signInWithOAuth({
+          provider: 'apple',
+          options: { redirectTo: `${window.location.origin}/auth/callback` }
+        });
+        if (authError || !oauthData?.url) throw authError;
+      }
+    } catch (err: any) {
+      if (err?.code !== 'SIGN_IN_CANCELLED') {
+        console.error('Apple login error:', err);
+      }
+    } finally {
+      appleLoading = false;
+    }
+  }
 
   async function handleGoogleLogin() {
     loading = true;
@@ -157,7 +207,18 @@
       {/if}
 
       {#if !resetMode}
-        <div class="mb-4">
+        <div class="mb-4 flex flex-col gap-3">
+          <button
+            type="button"
+            onclick={handleAppleLogin}
+            disabled={appleLoading}
+            class="w-full transition-all duration-300 flex items-center justify-center gap-3 bg-black text-white px-4 py-3 font-semibold border-2 border-black hover:bg-gray-900 disabled:opacity-50 rounded-lg shadow-md hover:shadow-lg"
+          >
+            <svg width="18" height="18" viewBox="0 0 814 1000" xmlns="http://www.w3.org/2000/svg" fill="white">
+              <path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76 0-103.7 40.8-165.9 40.8s-105-37.5-155.5-127.4C46.5 753.1 1 621.9 1 495.7c0-210.1 137.1-321.4 272-321.4 70.4 0 129.1 46.3 173.6 46.3 42.8 0 109.6-49 188.6-49 30.4 0 108.2 2.6 168.9 80.5zm-234.2-184.7c-6.5 30.4-23.4 60.2-49.7 84.2-31.7 28.3-70.4 50.3-112.5 47.1-1.3-5.2-2-10.4-2-16.3 0-27.7 13-58.1 36.4-82.8 11.7-12.3 26.7-22.7 44.9-30.4 18.2-7.8 35.4-12.4 51.6-13.7.6 4 1.3 8.5 1.3 11.9z"/>
+            </svg>
+            {appleLoading ? 'Redirecting...' : 'Continue with Apple'}
+          </button>
           <button
             type="button"
             onclick={handleGoogleLogin}


### PR DESCRIPTION
## Summary
Implements Sign in with Apple as required by App Store Review Guideline 4.8.

## What changed
- Installed \`@capacitor-community/apple-sign-in\`
- **iOS native**: uses \`SignInWithApple.authorize()\` → passes identity token to \`supabase.auth.signInWithIdToken()\` — no browser redirect needed
- **Web**: uses \`supabase.auth.signInWithOAuth({ provider: 'apple' })\` redirect flow
- Apple button added above Google button on all 3 login form variants
- Captures user's name on first sign-in (Apple only sends it once)

## Before submitting
- [ ] Add Sign in with Apple capability in Xcode (Signing & Capabilities → + Capability)
- [ ] Archive and upload new build

## Test plan
- [ ] Web: clicking Continue with Apple redirects to Apple login page
- [ ] iOS TestFlight: clicking Continue with Apple shows native Face ID / Apple ID sheet
- [ ] Successful login creates/logs in user and redirects to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)