### PR TITLE
Fix Apple sign in: full reload to persist server session

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -52,8 +52,8 @@
           });
         }
 
-        await fetch('/api/auth/sync', { method: 'POST' });
-        goto('/');
+        // Use full page reload so server picks up the new session from cookies
+        window.location.href = '/';
       } else {
         const { data: oauthData, error: authError } = await supabase.auth.signInWithOAuth({
           provider: 'apple',


### PR DESCRIPTION
signInWithIdToken sets browser session but not server cookies. Full page reload forces server to pick up the new session.