### PR TITLE
Fix Apple sign in: server-side session via apple-callback route

### DIFF
--- a/src/routes/auth/apple-callback/+server.ts
+++ b/src/routes/auth/apple-callback/+server.ts
@@ -1,0 +1,26 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { syncSupabaseUserWithDB } from '$lib/helpers/supabase-auth-helpers';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+  const access_token = url.searchParams.get('access_token');
+  const refresh_token = url.searchParams.get('refresh_token');
+
+  if (!access_token || !refresh_token) {
+    redirect(303, '/login?error=missing_tokens');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabase = (locals as any).supabase;
+
+  const { data, error } = await supabase.auth.setSession({ access_token, refresh_token });
+
+  if (error || !data.user) {
+    console.error('[apple-callback] setSession error:', error);
+    redirect(303, '/login?error=auth_failed');
+  }
+
+  await syncSupabaseUserWithDB(data.user, supabase);
+
+  redirect(303, '/');
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -46,14 +46,20 @@
 
         if (error) throw error;
 
+        // Get the session to pass tokens to server
+        const { data: { session } } = await supabase.auth.getSession();
+        alert(`[DEBUG] session after idToken: access_token=${session?.access_token?.slice(0,20)} refresh=${session?.refresh_token?.slice(0,10)}`);
+
+        if (!session) throw new Error('No session after sign in');
+
         if (givenName || familyName) {
           await supabase.auth.updateUser({
             data: { full_name: `${givenName ?? ''} ${familyName ?? ''}`.trim() }
           });
         }
 
-        // Use full page reload so server picks up the new session from cookies
-        window.location.href = '/';
+        // Pass tokens to server route so it can set proper auth cookies
+        window.location.href = `/auth/apple-callback?access_token=${session.access_token}&refresh_token=${session.refresh_token}`;
       } else {
         const { data: oauthData, error: authError } = await supabase.auth.signInWithOAuth({
           provider: 'apple',


### PR DESCRIPTION
After signInWithIdToken succeeds on the client, pass access/refresh tokens to /auth/apple-callback which calls setSession server-side so SvelteKit auth cookies are properly set.