### PR TITLE
Fix Apple callback: POST tokens instead of URL params

### DIFF
--- a/src/routes/auth/apple-callback/+server.ts
+++ b/src/routes/auth/apple-callback/+server.ts
@@ -1,4 +1,4 @@
-import { redirect } from '@sveltejs/kit';
+import { json, redirect } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { syncSupabaseUserWithDB } from '$lib/helpers/supabase-auth-helpers';
 
@@ -12,15 +12,33 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const supabase = (locals as any).supabase;
-
   const { data, error } = await supabase.auth.setSession({ access_token, refresh_token });
 
   if (error || !data.user) {
-    console.error('[apple-callback] setSession error:', error);
+    console.error('[apple-callback GET] setSession error:', error);
     redirect(303, '/login?error=auth_failed');
   }
 
   await syncSupabaseUserWithDB(data.user, supabase);
-
   redirect(303, '/');
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+  const { access_token, refresh_token } = await request.json();
+
+  if (!access_token || !refresh_token) {
+    return json({ error: 'Missing tokens' }, { status: 400 });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabase = (locals as any).supabase;
+  const { data, error } = await supabase.auth.setSession({ access_token, refresh_token });
+
+  if (error || !data.user) {
+    console.error('[apple-callback POST] setSession error:', error);
+    return json({ error: 'Auth failed', detail: error?.message }, { status: 401 });
+  }
+
+  await syncSupabaseUserWithDB(data.user, supabase);
+  return json({ ok: true });
 };

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -58,8 +58,14 @@
           });
         }
 
-        // Pass tokens to server route so it can set proper auth cookies
-        window.location.href = `/auth/apple-callback?access_token=${session.access_token}&refresh_token=${session.refresh_token}`;
+        // POST tokens to server so it can set auth cookies, then reload
+        const res = await fetch('/auth/apple-callback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ access_token: session.access_token, refresh_token: session.refresh_token })
+        });
+        alert(`[DEBUG] apple-callback response: ${res.status} ${res.url}`);
+        window.location.href = '/';
       } else {
         const { data: oauthData, error: authError } = await supabase.auth.signInWithOAuth({
           provider: 'apple',


### PR DESCRIPTION
Access tokens are too long for URL params. Use POST with JSON body instead, then reload to home.