### PR TITLE
Fix Apple sign in: sync DB user before server redirect

### DIFF
--- a/src/routes/api/auth/sync/+server.ts
+++ b/src/routes/api/auth/sync/+server.ts
@@ -1,14 +1,36 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { syncSupabaseUserWithDB } from '$lib/helpers/supabase-auth-helpers';
+import { createClient } from '@supabase/supabase-js';
+import { PUBLIC_SUPABASE_URL } from '$env/static/public';
+import { env } from '$env/dynamic/private';
 
-export const POST: RequestHandler = async ({ locals }) => {
-  const { session, supabase } = locals;
-  if (!session) return json({ error: 'Not authenticated' }, { status: 401 });
+export const POST: RequestHandler = async ({ locals, request }) => {
+  // Try server-side session first (standard flow)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { session, supabase } = locals as any;
 
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return json({ error: 'No user' }, { status: 401 });
+  if (session) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return json({ error: 'No user' }, { status: 401 });
+    await syncSupabaseUserWithDB(user, supabase);
+    return json({ ok: true });
+  }
 
-  await syncSupabaseUserWithDB(user, supabase);
-  return json({ ok: true });
+  // Fallback: accept access_token in body (native Apple/Google sign-in where
+  // server cookies aren't set yet during the first request)
+  try {
+    const body = await request.json().catch(() => null);
+    const accessToken = body?.access_token;
+    if (!accessToken) return json({ error: 'Not authenticated' }, { status: 401 });
+
+    const adminSupabase = createClient(PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY ?? '');
+    const { data: { user }, error } = await adminSupabase.auth.getUser(accessToken);
+    if (error || !user) return json({ error: 'Invalid token' }, { status: 401 });
+
+    await syncSupabaseUserWithDB(user, adminSupabase);
+    return json({ ok: true });
+  } catch {
+    return json({ error: 'Not authenticated' }, { status: 401 });
+  }
 };

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -58,8 +58,12 @@
         if (code) {
           const { data, error: sessionError } = await supabase.auth.exchangeCodeForSession(code);
           alert(`[DEBUG Apple] exchangeCodeForSession error: ${JSON.stringify(sessionError)} user: ${data?.user?.id?.slice(0,8)}`);
-          if (!sessionError) {
-            const syncRes = await fetch('/api/auth/sync', { method: 'POST' });
+          if (!sessionError && data.session) {
+            const syncRes = await fetch('/api/auth/sync', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ access_token: data.session.access_token })
+            });
             alert(`[DEBUG Apple] sync response: ${syncRes.status}`);
             goto('/');
           }


### PR DESCRIPTION
hooks.server.ts calls signOut() if the user isn't in the DB. Apple native sign-in sets the client session but not server cookies, so the sync endpoint returned 401. Fix: accept access_token in sync body and use admin client to validate and sync the user.