### PR TITLE
Fix Apple sign in: setSession on server supabase to set auth cookies

### DIFF
--- a/src/routes/api/auth/sync/+server.ts
+++ b/src/routes/api/auth/sync/+server.ts
@@ -59,6 +59,19 @@ export const POST: RequestHandler = async ({ locals, request }) => {
     try {
       await syncSupabaseUserWithDB(user, adminSupabase);
       console.log('[sync] Token flow sync OK');
+
+      // Also set cookies on locals.supabase so subsequent server requests see the session
+      const refreshToken = body?.refresh_token;
+      if (refreshToken) {
+        const { error: setSessionError } = await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken
+        });
+        console.log('[sync] setSession on locals.supabase error:', setSessionError?.message);
+      } else {
+        console.log('[sync] No refresh_token in body — cookies not set');
+      }
+
       return json({ ok: true });
     } catch (err) {
       console.error('[sync] Token flow sync error:', err);

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -62,10 +62,14 @@
             const syncRes = await fetch('/api/auth/sync', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ access_token: data.session.access_token })
+              body: JSON.stringify({
+                access_token: data.session.access_token,
+                refresh_token: data.session.refresh_token
+              })
             });
             alert(`[DEBUG Apple] sync response: ${syncRes.status}`);
-            goto('/');
+            // Full reload to pick up server-side session cookies that sync just set
+            window.location.href = '/';
           }
         }
         appleLoading = false;


### PR DESCRIPTION
After validating JWT and syncing user, call locals.supabase.auth.setSession() with both tokens so the server client writes proper auth cookies on the response. Use full reload after so subsequent requests use the new cookies.