### PR TITLE
fix: App Store review fixes — remove debug alerts and add EULA links

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -33,6 +33,7 @@
           <li><a href="/keyboard" class="hover:text-text-100 transition-all duration-200 hover:translate-x-1 inline-block">Virtual Keyboard</a></li>
           <li><a href="/sitemap.xml" class="hover:text-text-100 transition-all duration-200 hover:translate-x-1 inline-block">Sitemap</a></li>
           <li><a href="/privacy" class="hover:text-text-100 transition-all duration-200 hover:translate-x-1 inline-block">Privacy Policy</a></li>
+          <li><a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/" target="_blank" class="hover:text-text-100 transition-all duration-200 hover:translate-x-1 inline-block">Terms of Use</a></li>
         </ul>
       </div>
       <div class="space-y-4">

--- a/src/lib/components/PaywallModal.svelte
+++ b/src/lib/components/PaywallModal.svelte
@@ -65,6 +65,11 @@
     <!-- Footer / Action -->
     <div class="p-6 pt-0">
       <SubscribeButton className="!py-3 !text-lg w-full shadow-md" />
+      <p class="mt-3 text-xs text-text-200 text-center">
+        By subscribing you agree to our
+        <a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/" target="_blank" class="underline">Terms of Use</a>
+        and <a href="/privacy" class="underline">Privacy Policy</a>.
+      </p>
     </div>
   </div>
 </Modal>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -18,9 +18,11 @@
 
   let appUrlListener: { remove: () => void } | null = null;
   let appleLoading = $state(false);
+  let appleError = $state<string | null>(null);
 
   async function handleAppleLogin() {
     appleLoading = true;
+    appleError = null;
     const isNative = !!(window as any).Capacitor?.isNativePlatform?.();
 
     const redirectUrl = isNative
@@ -37,6 +39,7 @@
 
     if (authError || !oauthData?.url) {
       console.error('Apple login error:', authError?.message);
+      appleError = 'Sign in failed. Please try again.';
       appleLoading = false;
       return;
     }
@@ -54,25 +57,37 @@
         try { await Browser.close(); } catch {}
 
         const code = new URL(url).searchParams.get('code');
-        alert(`[DEBUG Apple] deep link received, code present: ${!!code}`);
-        if (code) {
-          const { data, error: sessionError } = await supabase.auth.exchangeCodeForSession(code);
-          alert(`[DEBUG Apple] exchangeCodeForSession error: ${JSON.stringify(sessionError)} user: ${data?.user?.id?.slice(0,8)}`);
-          if (!sessionError && data.session) {
-            const syncRes = await fetch('/api/auth/sync', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                access_token: data.session.access_token,
-                refresh_token: data.session.refresh_token
-              })
-            });
-            alert(`[DEBUG Apple] sync response: ${syncRes.status}`);
-            // Full reload to pick up server-side session cookies that sync just set
-            window.location.href = '/';
-          }
+        if (!code) {
+          appleError = 'Sign in failed. Please try again.';
+          appleLoading = false;
+          return;
         }
-        appleLoading = false;
+
+        const { data, error: sessionError } = await supabase.auth.exchangeCodeForSession(code);
+        if (sessionError || !data.session) {
+          console.error('Apple exchangeCodeForSession error:', sessionError?.message);
+          appleError = 'Sign in failed. Please try again.';
+          appleLoading = false;
+          return;
+        }
+
+        const syncRes = await fetch('/api/auth/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            access_token: data.session.access_token,
+            refresh_token: data.session.refresh_token
+          })
+        });
+
+        if (!syncRes.ok) {
+          console.error('Apple sync failed:', syncRes.status);
+          appleError = 'Sign in failed. Please try again.';
+          appleLoading = false;
+          return;
+        }
+
+        window.location.href = '/';
       });
     }
     // On web, supabase handles redirect automatically via /auth/callback
@@ -217,6 +232,11 @@
       {/if}
 
       {#if !resetMode}
+        {#if appleError}
+          <div class="mb-4 p-3 bg-red-100 border-2 border-red-400 text-red-700 rounded-lg text-sm">
+            {appleError}
+          </div>
+        {/if}
         <div class="mb-4 flex flex-col gap-3">
           <button
             type="button"

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -132,6 +132,11 @@
                         </ul>
                         <div class="mt-8">
                           <SubscribeButton className="!py-3 !text-lg w-full" />
+                          <p class="mt-3 text-xs text-text-200 text-center">
+                            By subscribing you agree to our
+                            <a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/" target="_blank" class="underline">Terms of Use</a>
+                            and <a href="/privacy" class="underline">Privacy Policy</a>.
+                          </p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- **Guideline 2.1(a)**: Removed three `alert()` debug calls from `handleAppleLogin` in the login page. These were firing as native iOS dialog boxes on every Apple sign-in attempt, which the reviewer reported as "an error message appeared." Also hardened error handling so `appleLoading` resets and an inline error message shows on all failure paths.
- **Guideline 3.1.2(c)**: Added Apple Standard EULA + Privacy Policy links below the Subscribe button in `PaywallModal.svelte` and `pricing/+page.svelte`, and added a Terms of Use link to the footer.

## Remaining human tasks in App Store Connect
- Add to App Description: `"By subscribing, you agree to Apple's Terms of Use: https://www.apple.com/legal/internet-services/itunes/dev/stdeula/"`
- Fix or delete the promotional image (text too small — Guideline 2.3.2)
- Clarify IAP subscription description (Guideline 3.1.2(c) — what user receives)

## Test plan
- [ ] Build on iPad simulator, tap "Continue with Apple" — no alert dialogs appear
- [ ] Cancel Apple sign-in — loading spinner resets, no stuck state
- [ ] Open paywall modal — Terms of Use and Privacy Policy links visible and tappable
- [ ] Visit `/pricing` — same links below the Subscribe button
- [ ] Check footer — Terms of Use link present in Resources column

🤖 Generated with [Claude Code](https://claude.com/claude-code)