### PR TITLE
fix: prevent raw JSON from rendering in tutor chat UI

### DIFF
--- a/src/routes/api/translate-user-message/+server.ts
+++ b/src/routes/api/translate-user-message/+server.ts
@@ -135,31 +135,31 @@ Do not include a suggestedSentence field for English input — the arabic field 
     try {
       parsedResponse = parseJsonFromGeminiResponse(responseContent, translationWithFeedbackSchema.zodSchema);
     } catch (parseError) {
-      // Fallback: create a structured response
-      if (actualIsArabic) {
-        parsedResponse = {
-          arabic: message,
-          english: message,
-          transliteration: message
-        };
-      } else {
-        parsedResponse = {
-          arabic: message,
-          english: message,
-          transliteration: message
-        };
+      // Fallback: try raw JSON.parse without schema validation to salvage fields
+      try {
+        const rawParsed = JSON.parse(responseContent) as Record<string, unknown>;
+        if (rawParsed && typeof rawParsed === 'object' && typeof rawParsed.arabic === 'string') {
+          parsedResponse = rawParsed;
+        } else {
+          throw new Error('Missing arabic field in parsed response');
+        }
+      } catch {
+        console.error('Translate: failed to parse Gemini response as JSON:', responseContent?.substring(0, 200));
+        throw new Error('Failed to parse AI response');
       }
+    }
+
+    // Guard: reject if any field still contains raw JSON
+    const looksLikeJson = (s: string) => s.trimStart().startsWith('{') || s.trimStart().startsWith('[');
+    if (looksLikeJson(parsedResponse.arabic) || looksLikeJson(parsedResponse.english)) {
+      console.error('Detected raw JSON in translate response fields, aborting');
+      throw new Error('AI response contains unparsed JSON');
     }
 
     // Validate the response structure
     if (!parsedResponse.arabic || !parsedResponse.english || !parsedResponse.transliteration) {
-      // Fallback
-      parsedResponse = {
-        arabic: actualIsArabic ? message : message,
-        english: actualIsArabic ? message : message,
-        transliteration: message,
-        feedback: ''
-      };
+      console.error('Translate: incomplete response structure:', JSON.stringify(parsedResponse).substring(0, 200));
+      throw new Error('Incomplete AI response structure');
     }
 
     // Note: Nile4 model removed from tutor route to reduce latency

--- a/src/routes/api/tutor-chat/+server.ts
+++ b/src/routes/api/tutor-chat/+server.ts
@@ -170,22 +170,31 @@ IMPORTANT: wordAlignments must have one entry per Arabic word in your response, 
     try {
       parsedResponse = parseJsonFromGeminiResponse(responseContent, translationSchema.zodSchema);
     } catch (parseError) {
-      // Fallback: create a structured response from plain text
-      parsedResponse = {
-        arabic: responseContent,
-        english: responseContent,
-        transliteration: responseContent
-      };
+      // Fallback: try raw JSON.parse without schema validation to salvage fields
+      try {
+        const rawParsed = JSON.parse(responseContent) as Record<string, unknown>;
+        if (rawParsed && typeof rawParsed === 'object' && typeof rawParsed.arabic === 'string') {
+          parsedResponse = rawParsed;
+        } else {
+          throw new Error('Missing arabic field in parsed response');
+        }
+      } catch {
+        console.error('Tutor: failed to parse Gemini response as JSON:', responseContent?.substring(0, 200));
+        throw new Error('Failed to parse AI response');
+      }
+    }
+
+    // Guard: reject if any field still contains raw JSON
+    const looksLikeJson = (s: string) => s.trimStart().startsWith('{') || s.trimStart().startsWith('[');
+    if (looksLikeJson(parsedResponse.arabic) || looksLikeJson(parsedResponse.english)) {
+      console.error('Detected raw JSON in tutor response fields, aborting');
+      throw new Error('AI response contains unparsed JSON');
     }
 
     // Validate the response structure
     if (!parsedResponse.arabic || !parsedResponse.english || !parsedResponse.transliteration) {
-      // If structure is incomplete, use the Arabic text for all fields as fallback
-      parsedResponse = {
-        arabic: parsedResponse.arabic || responseContent,
-        english: parsedResponse.english || responseContent,
-        transliteration: parsedResponse.transliteration || responseContent
-      };
+      console.error('Tutor: incomplete response structure:', JSON.stringify(parsedResponse).substring(0, 200));
+      throw new Error('Incomplete AI response structure');
     }
 
     // Save the tutor's response if we have a conversation


### PR DESCRIPTION
## Summary

- When Gemini's structured output passes `JSON.parse` but fails Zod schema validation, the old fallback assigned the raw JSON string directly to the `arabic`/`english`/`transliteration` fields — causing the UI to render content like `{ "arabic": "كيفك", "english": "how are you (m)", ... }` as plain text
- Fixed in both `/api/tutor-chat` and `/api/translate-user-message`
- New fallback attempts a schema-free `JSON.parse` to salvage the actual field values; if that also fails, throws so the outer handler returns a 500 (an error state is better than displaying garbage)
- Added a belt-and-suspenders guard that detects if any response field still contains a raw JSON string and aborts before the response is sent

## Test plan

- [ ] Send messages in the tutor chat and verify Arabic text renders correctly (not as JSON)
- [ ] Check server logs — parse failures should now log clearly and return 500 instead of raw JSON
- [ ] Verify the UI handles a 500 error gracefully (existing error handling in `+page.svelte`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)