### PR TITLE
fix: pass App Store review (3.1.2c subscription disclosure + 2.1b Continue button)

### DIFF
--- a/src/lib/components/SubscribeButton.svelte
+++ b/src/lib/components/SubscribeButton.svelte
@@ -3,6 +3,8 @@
   import Button from '$lib/components/Button.svelte';
   import { onMount } from 'svelte';
   import { invalidateAll } from '$app/navigation';
+  import { page } from '$app/state';
+  import { RevenueCatService } from '$lib/services/revenuecat.service';
 
   type Props = {
     label?: string;
@@ -12,7 +14,7 @@
 
   let { label = 'Subscribe Now', className = '', nativeClass = '' }: Props = $props();
 
-  let isNative = $state(false);
+  let isNative = $state<boolean | null>(null);
   let isPurchasing = $state(false);
   let purchaseError = $state<string | null>(null);
 
@@ -24,15 +26,36 @@
     isPurchasing = true;
     purchaseError = null;
     try {
-      const { RevenueCatUI } = await import('@revenuecat/purchases-capacitor-ui');
-      const result = await RevenueCatUI.presentPaywall();
-      if (result.paywallResult === 'PURCHASED' || result.paywallResult === 'RESTORED') {
+      const userId = page.data.user?.id;
+      if (!userId) {
+        purchaseError = 'Please sign in before subscribing.';
+        return;
+      }
+
+      await RevenueCatService.initialize(userId);
+
+      const pkg = await RevenueCatService.getCurrentOffering();
+      if (!pkg) {
+        purchaseError = 'No subscription products available. Please try again later.';
+        return;
+      }
+
+      const customerInfo = await RevenueCatService.purchasePackage(pkg);
+
+      if (RevenueCatService.isEntitlementActive(customerInfo)) {
         await fetch('/api/verify-apple-purchase', { method: 'POST' });
         await invalidateAll();
       }
     } catch (err: any) {
-      if (err?.code !== 'PURCHASE_CANCELLED') {
-        purchaseError = 'Purchase failed. Please try again.';
+      const code = err?.code ?? err?.errorCode;
+      const userCancelled =
+        code === 'PURCHASE_CANCELLED' ||
+        code === 1 ||
+        err?.userCancelled === true ||
+        /cancel/i.test(String(err?.message ?? ''));
+      if (!userCancelled) {
+        purchaseError = err?.message || 'Purchase failed. Please try again.';
+        console.error('Apple purchase failed:', err);
       }
     } finally {
       isPurchasing = false;
@@ -44,7 +67,11 @@
   <p class="text-red-400 text-sm mb-2 text-center">{purchaseError}</p>
 {/if}
 
-{#if isNative}
+{#if isNative === null}
+  <Button type="button" disabled={true} className={className}>
+    Loading…
+  </Button>
+{:else if isNative}
   <Button
     type="button"
     onClick={handleApplePurchase}

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -132,9 +132,24 @@
                         </ul>
                         <div class="mt-8">
                           <SubscribeButton className="!py-3 !text-lg w-full" />
+                          <div class="mt-4 text-xs text-text-200 leading-relaxed text-left bg-tile-300 border border-tile-600 rounded-md p-4">
+                            <p class="font-semibold text-text-300 mb-2">Subscription: Parallel Arabic Premium</p>
+                            <ul class="list-disc list-inside mb-3 space-y-1">
+                              <li>Length: 1 month, auto-renewing</li>
+                              <li>Price: $10.00 USD per month</li>
+                            </ul>
+                            <p>
+                              Payment will be charged to your Apple ID account at the confirmation of purchase.
+                              Subscription automatically renews unless auto-renew is turned off at least 24 hours
+                              before the end of the current period. Your account will be charged for renewal
+                              within 24 hours prior to the end of the current period at the same $10.00 USD price.
+                              You can manage your subscription and turn off auto-renewal in your Apple ID
+                              Account Settings after purchase.
+                            </p>
+                          </div>
                           <p class="mt-3 text-xs text-text-200 text-center">
                             By subscribing you agree to our
-                            <a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/" target="_blank" class="underline">Terms of Use</a>
+                            <a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/" target="_blank" class="underline">Terms of Use (EULA)</a>
                             and <a href="/privacy" class="underline">Privacy Policy</a>.
                           </p>
                         </div>


### PR DESCRIPTION
## Summary

Resubmission fix for App Store rejection of build 1.0 (5) on iPad Air (M3) running iPadOS 26.5.

- **2.1(b) — Unresponsive Continue button**: replaced `RevenueCatUI.presentPaywall()` with a direct `Purchases.purchasePackage()` call from our own Subscribe Now button. The native StoreKit purchase sheet (rendered by iOS itself) now handles the transaction — the third-party paywall whose Continue button was unresponsive is no longer used.
- **3.1.2(c) — Subscription description**: added the required auto-renewable subscription disclosure block on `/pricing` directly under Subscribe Now, including subscription title, 1-month duration, $10.00 USD/month price, full auto-renewal terms, cancel-in-Settings instructions, and EULA/Privacy links.
- Hardened `SubscribeButton.svelte` against an SSR race where `isNative` defaulted to `false` and briefly rendered the Stripe form path inside the iOS WebView; now renders a disabled placeholder until platform detection resolves on mount.

## Test plan

- [ ] Deploy to Vercel so `www.parallel-arabic.com` serves the new code (the iOS app's `capacitor.config.ts` points `server.url` there — TestFlight builds will keep showing the OLD paywall until prod is updated).
- [ ] Open `/pricing` on web — disclosure block renders under Subscribe Now; Stripe checkout still works.
- [ ] Build for iOS (`npm run cap:sync && npx cap open ios`), bump build number, archive, upload to TestFlight.
- [ ] In TestFlight on iPad Air: sign in with a Sandbox tester (Settings → App Store → Sandbox Account), tap Subscribe Now, complete the native StoreKit purchase sheet, verify `/profile` reflects active subscription.
- [ ] Test purchase cancel — no error toast shown.
- [ ] Confirm App Store Connect: Paid Apps Agreement active, monthly subscription product Ready to Submit with price = $10.00 USD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)