### PR TITLE
fix: surface subscription verify errors and add success feedback

### DIFF
--- a/src/lib/components/SubscribeButton.svelte
+++ b/src/lib/components/SubscribeButton.svelte
@@ -17,6 +17,7 @@
   let isNative = $state<boolean | null>(null);
   let isPurchasing = $state(false);
   let purchaseError = $state<string | null>(null);
+  let purchaseSuccess = $state<string | null>(null);
 
   onMount(() => {
     isNative = !!(window as any).Capacitor?.isNativePlatform?.();
@@ -25,6 +26,7 @@
   async function handleApplePurchase() {
     isPurchasing = true;
     purchaseError = null;
+    purchaseSuccess = null;
     try {
       const userId = page.data.user?.id;
       if (!userId) {
@@ -42,10 +44,30 @@
 
       const customerInfo = await RevenueCatService.purchasePackage(pkg);
 
-      if (RevenueCatService.isEntitlementActive(customerInfo)) {
-        await fetch('/api/verify-apple-purchase', { method: 'POST' });
-        await invalidateAll();
+      if (!RevenueCatService.isEntitlementActive(customerInfo)) {
+        purchaseError = 'Payment succeeded but the subscription is not yet active. Please contact support if this persists.';
+        return;
       }
+
+      const verifyRes = await fetch('/api/verify-apple-purchase', { method: 'POST' });
+      const verifyData = await verifyRes.json().catch(() => ({}));
+
+      if (!verifyRes.ok) {
+        purchaseError =
+          verifyData?.error ||
+          'Payment succeeded but we could not save your subscription. Please contact support.';
+        console.error('[SubscribeButton] verify failed:', verifyRes.status, verifyData);
+        return;
+      }
+
+      if (verifyData?.active === false) {
+        purchaseError =
+          'Payment succeeded but your subscription has not propagated yet. It should activate within a minute — refresh the page.';
+        return;
+      }
+
+      await invalidateAll();
+      purchaseSuccess = 'Subscription activated. Enjoy Parallel Arabic Premium!';
     } catch (err: any) {
       const code = err?.code ?? err?.errorCode;
       const userCancelled =
@@ -65,6 +87,9 @@
 
 {#if purchaseError}
   <p class="text-red-400 text-sm mb-2 text-center">{purchaseError}</p>
+{/if}
+{#if purchaseSuccess}
+  <p class="text-green-400 text-sm mb-2 text-center">{purchaseSuccess}</p>
 {/if}
 
 {#if isNative === null}

--- a/src/routes/api/verify-apple-purchase/+server.ts
+++ b/src/routes/api/verify-apple-purchase/+server.ts
@@ -12,22 +12,44 @@ export const POST: RequestHandler = async ({ request, locals }) => {
   const userId = session.user.id;
 
   try {
-    const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
-      headers: {
-        Authorization: `Bearer ${env.REVENUECAT_API_KEY}`,
-        'X-Platform': 'ios'
-      }
-    });
+    if (!env.REVENUECAT_API_KEY) {
+      console.error('[verify-apple-purchase] REVENUECAT_API_KEY env var is not set');
+      return json(
+        { error: 'Server configuration error: subscription verification key is missing.' },
+        { status: 500 }
+      );
+    }
 
-    if (!res.ok) {
-      return json({ error: 'Failed to fetch subscriber info' }, { status: 502 });
+    let res: Response | null = null;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
+        headers: {
+          Authorization: `Bearer ${env.REVENUECAT_API_KEY}`,
+          'X-Platform': 'ios'
+        }
+      });
+      if (res.ok) break;
+      if (res.status === 403 || res.status === 401) break;
+      await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)));
+    }
+
+    if (!res || !res.ok) {
+      const status = res?.status ?? 0;
+      const bodyText = res ? await res.text().catch(() => '') : '';
+      console.error('[verify-apple-purchase] RevenueCat lookup failed', { status, body: bodyText, userId });
+      const message =
+        status === 401 || status === 403
+          ? 'Subscription verification credentials are invalid. Contact support.'
+          : 'Could not reach the subscription provider. Please try again in a moment.';
+      return json({ error: message, status }, { status: 502 });
     }
 
     const data = await res.json();
     const entitlement = data?.subscriber?.entitlements?.['Parallel Arabic Premium'];
 
     if (!entitlement) {
-      return json({ active: false });
+      console.warn('[verify-apple-purchase] No entitlement found for user', { userId });
+      return json({ active: false, reason: 'no_entitlement' });
     }
 
     const expiresDate = entitlement.expires_date ? new Date(entitlement.expires_date) : null;
@@ -47,7 +69,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
         })
         .eq('supabase_auth_id', userId);
 
-      if (error) console.error('[verify-apple-purchase] DB update error:', error);
+      if (error) {
+        console.error('[verify-apple-purchase] DB update error:', error);
+        return json({ error: 'Could not save subscription status. Please contact support.' }, { status: 500 });
+      }
     }
 
     return json({ active: isActive });


### PR DESCRIPTION
## Summary

Follow-up to #152. After a real iOS purchase, ` /api/verify-apple-purchase ` was returning 502 silently and ` is_subscriber ` was never flipped — a missing/incorrect ` REVENUECAT_API_KEY ` env var on Vercel surfaced as a 403 from RevenueCat with no UI signal. This PR makes failures loud and adds positive feedback on success.

- Server (` /api/verify-apple-purchase `):
  - Fail fast with a clear message when ` REVENUECAT_API_KEY ` is unset.
  - Retry transient RevenueCat REST errors with backoff (1.5s, 3s).
  - Skip retries on 401/403 — those are auth/config errors that won't fix themselves.
  - Return descriptive error JSON (` { error, status } `) so the client can show useful toasts.
  - Bubble DB update errors to the client instead of swallowing them.
- Client (` SubscribeButton.svelte `):
  - Read the verify response.
  - Red error toast when verify fails or returns ` active=false ` (with guidance to refresh).
  - Green success toast on successful activation.

## Test plan

- [ ] With ` REVENUECAT_API_KEY ` unset in Vercel: tapping Subscribe Now after a real Sandbox purchase shows "Server configuration error: subscription verification key is missing." (not silent).
- [ ] With a wrong key: shows "Subscription verification credentials are invalid. Contact support."
- [ ] With the correct Secret v1 key: the toast turns green ("Subscription activated…"), ` is_subscriber ` flips to true in Supabase, ` /profile ` shows the active subscription.
- [ ] Cancelling the StoreKit sheet still produces no error toast (PURCHASE_CANCELLED path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)