### PR TITLE
fix: subscription shows Free Plan after purchase + lost after app restart

### DIFF
--- a/src/lib/helpers/get-user-has-active-subscription.ts
+++ b/src/lib/helpers/get-user-has-active-subscription.ts
@@ -3,12 +3,14 @@ import { StripeService } from '$lib/services/stripe.service';
 import { isEmailWhitelisted } from './subscription';
 import { env } from '$env/dynamic/private';
 
+const ENTITLEMENT_ID = 'Parallel Arabic Premium';
+
 export const getUserHasActiveSubscription = async (userId: string | null) => {
   if (!userId) return false;
 
   const { data: user, error } = await supabase
     .from('user')
-    .select('id, subscriber_id, email, is_subscriber')
+    .select('id, subscriber_id, email, is_subscriber, subscription_end_date')
     .eq('id', userId)
     .single();
 
@@ -20,8 +22,24 @@ export const getUserHasActiveSubscription = async (userId: string | null) => {
 
   if (!user) return false;
 
-  // No subscriber_id — fall back to the DB boolean (covers race between purchase and webhook)
-  if (!user.subscriber_id) return user.is_subscriber ?? false;
+  // DB-first source of truth. verify-apple-purchase and Stripe webhooks write
+  // is_subscriber + subscription_end_date as the user-facing state of record.
+  // The provider REST call below is treated as a sanity check that can flip
+  // false → true (if the DB hasn't caught up), but never true → false on a
+  // single transient lookup — that's the job of webhooks / scheduled jobs,
+  // not a single-shot read.
+  const endDateMs = user.subscription_end_date ? Number(user.subscription_end_date) * 1000 : null;
+  const dbSaysActive = !!(
+    user.is_subscriber &&
+    (!endDateMs || endDateMs > Date.now())
+  );
+
+  if (dbSaysActive) return true;
+
+  // DB doesn't currently show an active sub. Try the provider as a last chance
+  // to confirm one we missed (e.g. webhook never fired, manual restore).
+
+  if (!user.subscriber_id) return false;
 
   // Stripe subscription IDs always start with "sub_"
   if (user.subscriber_id.startsWith('sub_')) {
@@ -46,12 +64,12 @@ export const getUserHasActiveSubscription = async (userId: string | null) => {
         Authorization: `Bearer ${env.REVENUECAT_API_KEY}`
       }
     });
-    if (!res.ok) return user.is_subscriber ?? false;
+    if (!res.ok) return false;
     const data = await res.json();
-    const entitlement = data?.subscriber?.entitlements?.['Parallel Arabic Premium'];
+    const entitlement = data?.subscriber?.entitlements?.[ENTITLEMENT_ID];
     if (!entitlement?.expires_date) return false;
     return new Date(entitlement.expires_date) > new Date();
   } catch {
-    return user.is_subscriber ?? false;
+    return false;
   }
 };

--- a/src/routes/api/revenuecat-webhook/+server.ts
+++ b/src/routes/api/revenuecat-webhook/+server.ts
@@ -75,7 +75,7 @@ export const POST: RequestHandler = async ({ request }) => {
           subscriber_id: original_transaction_id ?? null,
           subscription_end_date: subscriptionEndDate
         })
-        .eq('supabase_auth_id', app_user_id)
+        .eq('id', app_user_id)
         .select();
 
       console.log('[RC webhook] Update result - data:', JSON.stringify(data));
@@ -90,7 +90,7 @@ export const POST: RequestHandler = async ({ request }) => {
         const { data, error } = await adminSupabase
           .from('user')
           .update({ subscription_end_date: Math.floor(expiration_at_ms / 1000) })
-          .eq('supabase_auth_id', app_user_id)
+          .eq('id', app_user_id)
           .select();
 
         console.log('[RC webhook] Cancellation update - data:', JSON.stringify(data));
@@ -107,7 +107,7 @@ export const POST: RequestHandler = async ({ request }) => {
           subscriber_id: null,
           subscription_end_date: null
         })
-        .eq('supabase_auth_id', app_user_id)
+        .eq('id', app_user_id)
         .select();
 
       console.log('[RC webhook] Expiration update - data:', JSON.stringify(data));

--- a/src/routes/api/verify-apple-purchase/+server.ts
+++ b/src/routes/api/verify-apple-purchase/+server.ts
@@ -1,7 +1,8 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { supabase } from '$lib/supabaseClient';
+import { createClient } from '@supabase/supabase-js';
+import { PUBLIC_SUPABASE_URL } from '$env/static/public';
 
 const ENTITLEMENT_ID = 'Parallel Arabic Premium';
 
@@ -47,7 +48,30 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     return json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const userId = session.user.id;
+  const supabaseAuthId = session.user.id;
+
+  // The RevenueCat client SDK is initialized with `public.user.id` (the custom
+  // alphanumeric id, not the Supabase auth UUID). Look it up so our RC REST
+  // call queries the same subscriber the SDK created.
+  const adminSupabase = createClient(PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY ?? '');
+  const { data: dbUser, error: lookupError } = await adminSupabase
+    .from('user')
+    .select('id')
+    .eq('supabase_auth_id', supabaseAuthId)
+    .single();
+
+  if (lookupError || !dbUser?.id) {
+    console.error('[verify-apple-purchase] Could not look up user.id', {
+      supabaseAuthId,
+      error: lookupError
+    });
+    return json(
+      { error: 'Could not find your account. Please contact support.' },
+      { status: 500 }
+    );
+  }
+
+  const rcUserId = dbUser.id;
 
   // Optional client-provided customerInfo from the RevenueCat SDK. This is the
   // freshest source of truth on iOS — it came directly from StoreKit + the RC
@@ -75,7 +99,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
     // Defense in depth: try RC REST first. If it has the entitlement, trust it.
     for (let attempt = 0; attempt < 2; attempt++) {
-      const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${userId}`, {
+      const res = await fetch(`https://api.revenuecat.com/v1/subscribers/${rcUserId}`, {
         headers: { Authorization: `Bearer ${env.REVENUECAT_API_KEY}` }
       });
       restStatus = res.status;
@@ -110,29 +134,40 @@ export const POST: RequestHandler = async ({ request, locals }) => {
       if (fromClient?.isActive) {
         resolved = fromClient;
         console.log('[verify-apple-purchase] using client customerInfo as fallback', {
-          userId,
+          rcUserId,
           restStatus
         });
       }
     }
 
     if (!resolved?.isActive) {
-      console.warn('[verify-apple-purchase] No active entitlement found', { userId, restStatus });
+      console.warn('[verify-apple-purchase] No active entitlement found', { rcUserId, restStatus });
       return json({ active: false, reason: 'no_entitlement' });
     }
 
-    const { error } = await supabase
+    const { data: updatedRows, error } = await adminSupabase
       .from('user')
       .update({
         is_subscriber: true,
         subscriber_id: resolved.transactionId,
         subscription_end_date: resolved.expiresMs ? Math.floor(resolved.expiresMs / 1000) : null
       })
-      .eq('supabase_auth_id', userId);
+      .eq('id', rcUserId)
+      .select('id');
 
     if (error) {
       console.error('[verify-apple-purchase] DB update error:', error);
       return json({ error: 'Could not save subscription status. Please contact support.' }, { status: 500 });
+    }
+
+    if (!updatedRows || updatedRows.length === 0) {
+      console.error('[verify-apple-purchase] DB update affected 0 rows', {
+        id: rcUserId
+      });
+      return json(
+        { error: 'Could not find your account to save the subscription. Please contact support.' },
+        { status: 500 }
+      );
     }
 
     return json({ active: true, source: resolved.source });


### PR DESCRIPTION
## Summary

After PR #157 a successful Apple purchase still showed Free Plan on /profile, and the subscription disappeared when the app was closed and reopened. Three bugs were compounding:

### 1. ` verify-apple-purchase ` queried the wrong RevenueCat subscriber

The RC client SDK is initialized with ` data.user.id ` (the custom alphanumeric ` public.user.id `), so RC stores the entitlement under that id. But the endpoint was querying RC REST with ` session.user.id ` (the Supabase auth UUID) — a different identity. RC then auto-created an empty subscriber under the UUID and returned no entitlement, so the DB never got updated.

**Fix:** look up ` public.user.id ` from ` supabase_auth_id ` and use it for both the RC REST call and the DB UPDATE WHERE clause.

### 2. RevenueCat webhook never matched any row

The webhook ran ` WHERE supabase_auth_id = app_user_id `, but ` app_user_id ` is whatever was passed to ` Purchases.configure() ` — which is ` public.user.id `, not the UUID. So every INITIAL_PURCHASE / RENEWAL / EXPIRATION event silently affected 0 rows.

**Fix:** ` WHERE id = app_user_id `.

### 3. ` getUserHasActiveSubscription ` overruled the DB

It returned ` false ` whenever RC REST didn't show an active entitlement, even if the DB already had ` is_subscriber=true ` and ` subscription_end_date ` in the future. After a fresh purchase (or in any sandbox lag window) the profile page and several API routes flipped users back to Free Plan.

**Fix:** DB-first. ` is_subscriber AND end_date > now ` short-circuits to true. The provider call now only runs to UPGRADE a false DB state — never to flip true → false on a single transient lookup.

### Additional hardening

- ` verify-apple-purchase ` switched from the anon Supabase client to the service-role admin client. With RLS in play the anon path may have been silently affecting 0 rows even when the WHERE clause matched.
- Added a 0-rows-affected guard that returns a 500 with a clear error if the update doesn't land, so this kind of mismatch fails loudly next time.

## Test plan

- [ ] Sandbox purchase → green toast → page reloads → ` /profile ` shows ✓ Premium Active.
- [ ] Close and reopen the app → still Premium Active.
- [ ] Vercel logs: ` updatedRows ` length is 1, not 0.
- [ ] RC webhook logs (RENEWAL or EXPIRATION) show ` data ` with the matched row, not ` [] `.

🤖 Generated with [Claude Code](https://claude.com/claude-code)