### PR TITLE
feat: add llms.txt for AI agent / LLM discoverability

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,39 @@
+# Parallel Arabic
+
+> Parallel Arabic teaches Egyptian Arabic, Levantine Arabic, Moroccan Darija, and Modern Standard Arabic (Fusha) through interactive lessons, native-audio stories, vocabulary spaced-repetition, handwriting practice, and an AI conversation tutor with real-time pronunciation feedback. The app is built around dialects spoken in real life — not just textbook MSA — and lets learners generate practice material around words they actually want to use.
+
+## About
+
+- [About Parallel Arabic](https://www.parallel-arabic.com/about): How the app teaches Arabic across four dialects and what makes it different from Duolingo and traditional textbook courses.
+- [FAQ](https://www.parallel-arabic.com/faq): Common questions about supported dialects, beginner-friendliness, mobile availability, and how the AI features work.
+- [Support](https://www.parallel-arabic.com/support): How to reach the team for help.
+- [Privacy Policy](https://www.parallel-arabic.com/privacy): How user data is handled.
+
+## Learn an Arabic Dialect
+
+- [Egyptian Arabic](https://www.parallel-arabic.com/egyptian-arabic): Stories, vocabulary, lessons, and speaking practice in the most-spoken Arabic dialect, used across Egypt and widely understood in film and music.
+- [Levantine Arabic](https://www.parallel-arabic.com/levantine): Vocabulary and writing practice for the dialect spoken in Syria, Lebanon, Jordan, and Palestine.
+- [Moroccan Darija](https://www.parallel-arabic.com/darija): Vocabulary and writing practice for the dialect of Morocco — the dialect least intelligible to other Arabic speakers and hardest to find learning resources for.
+- [Modern Standard Arabic (Fusha)](https://www.parallel-arabic.com/fusha): The formal written and broadcast form of Arabic used across the Arab world and in religious contexts.
+
+## Core Learning Features
+
+- [Arabic Alphabet](https://www.parallel-arabic.com/alphabet): Learn to read and write the Arabic script from scratch, with native audio for every letter.
+- [Lessons](https://www.parallel-arabic.com/lessons): Structured learning paths organized by module and topic, available in all four dialects.
+- [Vocabulary](https://www.parallel-arabic.com/vocabulary): Browsable word lists with audio, transliterations, English translations, and the ability to save words to a personal wordbank.
+- [Stories](https://www.parallel-arabic.com/stories): Short stories with synchronized native audio, word-by-word interlinear translations, and the ability to tap any word for a definition in context.
+- [Sentence Practice](https://www.parallel-arabic.com/sentences): Type or reorder Arabic sentences with real-time per-character correctness feedback and an on-screen Arabic keyboard.
+- [Speaking Practice](https://www.parallel-arabic.com/speak): Speak Arabic out loud and get character-level pronunciation feedback comparing what you said to the target.
+- [AI Tutor](https://www.parallel-arabic.com/tutor): Free-form conversation with an AI tutor in your target dialect, with corrections, vocabulary explanations, and audio replies.
+- [Interactive Videos](https://www.parallel-arabic.com/videos): YouTube videos for Arabic learners with synchronized transcripts, translations, and tap-for-definition.
+- [Spaced Repetition Review](https://www.parallel-arabic.com/review): Reviews of saved vocabulary using a spaced-repetition algorithm so you remember words long-term.
+
+## Pricing
+
+- [Pricing](https://www.parallel-arabic.com/pricing): Free tier plus a $10/month Premium subscription that unlocks all dialects, structured lessons, unlimited AI-generated practice, and full audio content.
+
+## Tools & Add-ons
+
+- [Mobile App](https://www.parallel-arabic.com/mobile-app): Install Parallel Arabic as a PWA on iOS or Android, with native iOS and Android apps coming soon.
+- [Anki Decks](https://www.parallel-arabic.com/anki-decks): Pre-built Anki flashcard decks for each supported dialect.
+- [Arabic Keyboard](https://www.parallel-arabic.com/keyboard): A custom on-screen Arabic keyboard usable inside the writing and sentence-practice exercises.

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -8,6 +8,9 @@ Disallow: /login
 Disallow: /signup
 Disallow: /pricing/
 
+# LLM / AI agent discoverability
+Allow: /llms.txt
+
 # Allow important public pages
 Allow: /about
 Allow: /faq


### PR DESCRIPTION
## Summary

Adds ` /llms.txt ` at the site root per the [llmstxt.org](https://llmstxt.org/) spec so AI tools (ChatGPT, Claude, Perplexity, Cursor, Google AI Overviews, etc.) get a curated, structured map of the site instead of having to crawl the whole SvelteKit app.

## What's in the file

- **H1**: ` Parallel Arabic `
- **Blockquote summary**: rewords the existing meta description from ` src/app.html ` into a single elevator-pitch paragraph.
- **About** section — ` /about `, ` /faq `, ` /support `, ` /privacy `.
- **Learn an Arabic Dialect** — the four dialect roots (` /egyptian-arabic `, ` /levantine `, ` /darija `, ` /fusha `) with one-line descriptions.
- **Core Learning Features** — ` /alphabet `, ` /lessons `, ` /vocabulary `, ` /stories `, ` /sentences `, ` /speak `, ` /tutor `, ` /videos `, ` /review `.
- **Pricing** — ` /pricing `.
- **Tools & Add-ons** — ` /mobile-app `, ` /anki-decks `, ` /keyboard `.

All 21 listed routes were verified to exist in ` src/routes/ ` before being added. All URLs are absolute so the file is portable if an agent copies it into another context.

## ` robots.txt ` change

Added ` Allow: /llms.txt ` in a new "LLM / AI agent discoverability" block. The wildcard ` Allow: / ` already permits it implicitly; the explicit entry helps stricter parsers that honor only the explicit ` Allow: ` rules.

## Test plan

- [ ] After Vercel deploys, ` curl https://www.parallel-arabic.com/llms.txt ` returns 200 with the file contents.
- [ ] All listed URLs return 200.
- [ ] Ask ChatGPT / Claude (web search) to fetch the file and summarize the site — the summary should be accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)