### PR TITLE
feat: topic-based story generation for /stories

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -101,6 +101,20 @@ CREATE TABLE public.saved_word (
   CONSTRAINT saved_word_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.user(id),
   CONSTRAINT fk_saved_word_word_id FOREIGN KEY (word_id) REFERENCES public.word(id)
 );
+CREATE TABLE public.self_study_sessions (
+  id text NOT NULL,
+  user_id text NOT NULL,
+  title text NOT NULL,
+  dialect text NOT NULL,
+  level text NOT NULL DEFAULT 'intermediate'::text,
+  vocab_count integer NOT NULL DEFAULT 0,
+  step_count integer NOT NULL DEFAULT 0,
+  score_percent integer,
+  session_data_key text NOT NULL,
+  created_at bigint NOT NULL,
+  CONSTRAINT self_study_sessions_pkey PRIMARY KEY (id),
+  CONSTRAINT self_study_sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.user(id)
+);
 CREATE TABLE public.stories (
   id character varying NOT NULL,
   title character varying NOT NULL,
@@ -254,6 +268,15 @@ CREATE TABLE public.user_story_completion (
   created_at bigint NOT NULL,
   CONSTRAINT user_story_completion_pkey PRIMARY KEY (id),
   CONSTRAINT user_story_completion_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.user(id)
+);
+CREATE TABLE public.user_topic_story (
+  id text NOT NULL,
+  user_id text NOT NULL,
+  topic_id text NOT NULL,
+  story_id text NOT NULL,
+  created_at bigint NOT NULL,
+  CONSTRAINT user_topic_story_pkey PRIMARY KEY (id),
+  CONSTRAINT user_topic_story_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.user(id)
 );
 CREATE TABLE public.video (
   id text NOT NULL,

--- a/src/lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte
+++ b/src/lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte
@@ -24,10 +24,18 @@
 		showEnglish?: boolean;
 		showTransliteration?: boolean;
 		showTashkeel?: boolean;
+		savedWords?: Set<string>;
 	}
 
-	let { sentence, setActiveWord, dialect, showEnglish = true, showTransliteration = true, showTashkeel = false }: Props =
+	let { sentence, setActiveWord, dialect, showEnglish = true, showTransliteration = true, showTashkeel = false, savedWords = new Set() }: Props =
 		$props();
+
+	/** Strip punctuation and check if this Arabic word is in the user's saved word list */
+	function isSavedWord(arabic: string): boolean {
+		if (!savedWords.size) return false;
+		const normalized = arabic.replace(/[،,؟!.;:)(؛]/g, '').trim();
+		return savedWords.has(normalized) || savedWords.has(arabic.trim());
+	}
 
 	// Word cache for instant re-display on repeated clicks
 	let wordCache = new Map<string, string>();
@@ -239,7 +247,9 @@
 					'flex flex-col items-center px-2 py-2 sm:px-3 sm:py-3 rounded-lg transition-all duration-200 cursor-pointer group border-2',
 					isWordSelected(wordIndex)
 						? 'bg-blue-200 border-blue-400 shadow-md'
-						: 'border-transparent hover:bg-tile-500 hover:shadow-md hover:border-tile-600'
+						: isSavedWord(wordAlign.arabic)
+							? 'bg-amber-400/10 border-amber-400/40 hover:bg-amber-400/20 hover:border-amber-400 hover:shadow-md'
+							: 'border-transparent hover:bg-tile-500 hover:shadow-md hover:border-tile-600'
 				)}
 				onclick={() => fetchDefinition(wordAlign.arabic.replace(/[،,]/g, ''), wordAlign)}
 				onmousedown={(e) => handleWordMouseDown(wordIndex, e)}
@@ -272,7 +282,9 @@
 					'px-2 py-1 sm:px-3 sm:py-2 rounded-lg transition-all duration-200 cursor-pointer border-2 text-xl sm:text-2xl md:text-3xl font-semibold text-text-300',
 					isWordSelected(wordIndex)
 						? 'bg-blue-200 border-blue-400 shadow-md'
-						: 'border-transparent hover:bg-tile-500 hover:shadow-md hover:border-tile-600'
+						: isSavedWord(arabicWords[wordIndex] || arabicWord)
+							? 'bg-amber-400/10 border-amber-400/40 hover:bg-amber-400/20 hover:border-amber-400 hover:shadow-md'
+							: 'border-transparent hover:bg-tile-500 hover:shadow-md hover:border-tile-600'
 				)}
 				onclick={() => fetchDefinition((arabicWords[wordIndex] || arabicWord).replace(/[،,]/g, ''))}
 				onmousedown={(e) => handleWordMouseDown(wordIndex, e)}

--- a/src/lib/constants/story-topics.ts
+++ b/src/lib/constants/story-topics.ts
@@ -1,0 +1,229 @@
+export type TopicSection = 'start-here' | 'topics';
+
+export interface StoryTopic {
+	id: string;
+	name: string;
+	emoji: string;
+	section: TopicSection;
+	/** 1-sentence brief passed as `description` to the create-story API */
+	promptTemplate: string;
+}
+
+export const STORY_TOPICS: StoryTopic[] = [
+	// ── Start Here ─────────────────────────────────────────────────────────────
+	{
+		id: 'greetings',
+		name: 'Greetings',
+		emoji: '👋',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Greetings. Every sentence must involve characters greeting each other, saying hello, goodbye, or asking how someone is doing. The entire story revolves around these greeting exchanges.'
+	},
+	{
+		id: 'introducing-yourself',
+		name: 'Introducing Yourself',
+		emoji: '🤝',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Self-introduction. Every sentence must be about a character introducing themselves — their name, where they are from, what they do, and personal details. The story must stay entirely on the topic of meeting someone and sharing who you are.'
+	},
+	{
+		id: 'ordering-food',
+		name: 'Ordering Food',
+		emoji: '🍽️',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Ordering food. The entire story must take place at a restaurant or café. Every sentence must relate to looking at a menu, asking the waiter questions, ordering dishes, and receiving the food. Do not stray from this setting.'
+	},
+	{
+		id: 'asking-directions',
+		name: 'Getting Around',
+		emoji: '🗺️',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Asking for directions. Every sentence must involve someone asking for or giving directions in a city — street names, landmarks, left/right/straight, near/far. The story must stay entirely on the topic of navigating from one place to another.'
+	},
+	{
+		id: 'shopping',
+		name: 'Shopping',
+		emoji: '🛍️',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Shopping. The entire story must be set in a market or shop. Every sentence must relate to browsing items, asking about prices, negotiating, and paying. Do not leave the shopping context.'
+	},
+	{
+		id: 'numbers-counting',
+		name: 'Numbers & Counting',
+		emoji: '🔢',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Numbers and counting. Every sentence must contain at least one number — prices, quantities, ages, times, phone numbers, addresses, scores. Numbers and counting must be the central thread of the entire story.'
+	},
+	{
+		id: 'days-and-time',
+		name: 'Days & Time',
+		emoji: '📅',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Days of the week and telling the time. Every sentence must mention a specific day, time, date, or scheduling detail. The story must be entirely about planning, appointments, or a schedule.'
+	},
+	{
+		id: 'family',
+		name: 'Family',
+		emoji: '👨‍👩‍👧',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Family members. Every sentence must mention a family member by relationship (mother, father, brother, sister, grandmother, etc.) and what they are doing together. The story must revolve entirely around family interactions at home.'
+	},
+	{
+		id: 'at-the-cafe',
+		name: 'At the Café',
+		emoji: '☕',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: At a café. The entire story must be set inside a café. Every sentence must relate to drinks, pastries, the ambiance, the staff, or conversation happening at the café. Do not leave the café setting.'
+	},
+	{
+		id: 'daily-routine',
+		name: 'Daily Routine',
+		emoji: '🌅',
+		section: 'start-here',
+		promptTemplate: 'TOPIC: Daily routine. Every sentence must describe a specific step in a character\'s morning or evening routine — waking up, washing, eating, getting dressed, commuting. Follow the routine in chronological order from start to finish.'
+	},
+
+	// ── All Topics ─────────────────────────────────────────────────────────────
+	{
+		id: 'travel',
+		name: 'Travel',
+		emoji: '✈️',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Travel. The entire story must be about travelling — packing a bag, arriving at an airport or train station, boarding, landing, and arriving somewhere new. Every sentence must relate directly to the travel experience.'
+	},
+	{
+		id: 'work-career',
+		name: 'Work & Career',
+		emoji: '💼',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Work and career. The entire story must be set in a workplace. Every sentence must relate to work tasks, colleagues, a meeting, a job interview, or a professional challenge. Do not leave the work context.'
+	},
+	{
+		id: 'food-cooking',
+		name: 'Food & Cooking',
+		emoji: '🍳',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Cooking. The entire story must be set in a kitchen. Every sentence must describe a step in cooking a dish — chopping, mixing, heating, tasting, and serving. Stay in the kitchen from start to finish.'
+	},
+	{
+		id: 'health',
+		name: 'Health & Body',
+		emoji: '🏥',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Health and the doctor. The entire story must be set in a clinic or pharmacy. Every sentence must relate to symptoms, the doctor\'s examination, a diagnosis, medicine, or health advice. Stay entirely in the medical context.'
+	},
+	{
+		id: 'education',
+		name: 'Education',
+		emoji: '📚',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Education and school. The entire story must be set in a classroom, school, or university. Every sentence must relate to studying, a lesson, homework, exams, or a teacher-student interaction.'
+	},
+	{
+		id: 'weather',
+		name: 'Weather & Seasons',
+		emoji: '🌤️',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Weather. Every sentence must describe or react to the weather — rain, heat, wind, clouds, temperature, or a seasonal change. The weather must drive everything that happens in the story.'
+	},
+	{
+		id: 'home',
+		name: 'Home Life',
+		emoji: '🏠',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Life at home. The entire story must be set inside a home. Every sentence must describe a domestic activity — cleaning, cooking, watching TV, having guests, or a conversation between housemates or family members.'
+	},
+	{
+		id: 'entertainment',
+		name: 'Entertainment',
+		emoji: '🎬',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Entertainment. The entire story must be about going to the cinema, watching a film, attending a show, or listening to music. Every sentence must relate to the entertainment experience — the venue, the performance, and the reactions.'
+	},
+	{
+		id: 'sports-fitness',
+		name: 'Sports & Fitness',
+		emoji: '🏃',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Sports and exercise. The entire story must be set on a sports field, gym, or court. Every sentence must relate to physical activity — training, competing, scoring, or discussing a sport.'
+	},
+	{
+		id: 'nature-animals',
+		name: 'Nature & Animals',
+		emoji: '🌿',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Nature and animals. The entire story must be set outdoors in nature. Every sentence must describe the natural environment — plants, animals, the landscape, sounds, and smells of the natural world.'
+	},
+	{
+		id: 'emotions',
+		name: 'Emotions & Feelings',
+		emoji: '😊',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Emotions and feelings. Every sentence must explicitly name or describe an emotion a character is experiencing and explain why they feel that way. Happiness, sadness, fear, excitement, and surprise must be central to every sentence.'
+	},
+	{
+		id: 'celebrations',
+		name: 'Culture & Celebrations',
+		emoji: '🎉',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Celebrations. The entire story must take place during a cultural celebration or festival. Every sentence must relate to the festivities — decorations, food, music, family gathering, traditions, and the occasion being celebrated.'
+	},
+	{
+		id: 'technology',
+		name: 'Technology',
+		emoji: '📱',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Technology. Every sentence must involve a specific piece of technology — a phone, computer, app, or device. The story must revolve entirely around using, troubleshooting, or discovering technology.'
+	},
+	{
+		id: 'history-traditions',
+		name: 'History & Traditions',
+		emoji: '🏛️',
+		section: 'topics',
+		promptTemplate: 'TOPIC: History and Arab traditions. The entire story must be set at a historical site or involve a traditional cultural practice. Every sentence must reference history, heritage, or a long-standing tradition from the Arab world.'
+	},
+	{
+		id: 'music-arts',
+		name: 'Music & Arts',
+		emoji: '🎵',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Music and art. The entire story must be about creating, performing, or experiencing music or visual art. Every sentence must relate to an instrument, a song, a painting, a concert, or an artistic process.'
+	},
+	{
+		id: 'friendship',
+		name: 'Friendship',
+		emoji: '🫂',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Friendship. Every sentence must be about the relationship between two or more friends — spending time together, helping each other, resolving a disagreement, or reminiscing about shared memories. Stay entirely on the theme of friendship.'
+	},
+	{
+		id: 'business-economy',
+		name: 'Business',
+		emoji: '💰',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Business and money. The entire story must be about a business situation — negotiating a deal, managing a shop, discussing prices, or starting a small venture. Every sentence must relate directly to commerce or money.'
+	},
+	{
+		id: 'humor',
+		name: 'Humor & Comedy',
+		emoji: '😄',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Comedy and misunderstanding. Every sentence must build toward or be part of a funny situation — a misunderstanding, a mix-up, an embarrassing moment, or a comic reaction. The entire story must be lighthearted and amusing.'
+	},
+	{
+		id: 'childhood-memories',
+		name: 'Childhood',
+		emoji: '🧒',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Childhood memories. Every sentence must be a specific memory from childhood — a game, a school moment, a family trip, or a lesson learned as a child. The story must be told entirely from the perspective of remembering the past.'
+	},
+	{
+		id: 'science-curiosity',
+		name: 'Science & Discovery',
+		emoji: '🔬',
+		section: 'topics',
+		promptTemplate: 'TOPIC: Science and discovery. Every sentence must describe a specific scientific observation, experiment, or discovery. The story must stay entirely on the topic of how something works or what someone learned through curiosity and investigation.'
+	}
+];
+
+export const START_HERE_TOPICS = STORY_TOPICS.filter(t => t.section === 'start-here');
+export const ALL_TOPICS = STORY_TOPICS.filter(t => t.section === 'topics');

--- a/src/lib/helpers/story-helpers.ts
+++ b/src/lib/helpers/story-helpers.ts
@@ -223,6 +223,7 @@ export async function getStoriesPaginated(
     dialect?: string;
     difficulty?: string;
     search?: string;
+    userId?: string;
   }
 ): Promise<PaginatedStoriesResult> {
   try {
@@ -244,6 +245,10 @@ export async function getStoriesPaginated(
 
     if (filters?.difficulty && filters.difficulty !== 'all') {
       query = query.ilike('difficulty', filters.difficulty);
+    }
+
+    if (filters?.userId) {
+      query = query.eq('user_id', filters.userId);
     }
 
     const { data: storiesMetadata, error: dbError } = await query;

--- a/src/lib/utils/gemini-json-parser.ts
+++ b/src/lib/utils/gemini-json-parser.ts
@@ -436,7 +436,17 @@ export function parseJsonFromGeminiResponse<T = unknown>(
 		const parsed = JSON.parse(sanitized);
 		console.log('[Gemini JSON Parser] Parse successful, validating with Zod...');
 		console.log('[Gemini JSON Parser] Parsed type:', Array.isArray(parsed) ? 'array' : typeof parsed);
-		
+
+		// Truncate oversized arrays that Gemini sometimes returns
+		if (parsed && typeof parsed === 'object') {
+			if (Array.isArray(parsed.keyVocab) && parsed.keyVocab.length > 15) {
+				parsed.keyVocab = parsed.keyVocab.slice(0, 15);
+			}
+			if (parsed.quiz?.questions && Array.isArray(parsed.quiz.questions) && parsed.quiz.questions.length > 5) {
+				parsed.quiz.questions = parsed.quiz.questions.slice(0, 5);
+			}
+		}
+
 		// Try direct validation first
 		try {
 			const validated = zodSchema.parse(parsed);
@@ -470,7 +480,16 @@ export function parseJsonFromGeminiResponse<T = unknown>(
 			const parsed = JSON.parse(repaired);
 			console.log('[Gemini JSON Parser] Repaired parse successful, validating with Zod...');
 			console.log('[Gemini JSON Parser] Parsed type:', Array.isArray(parsed) ? 'array' : typeof parsed);
-			
+
+			if (parsed && typeof parsed === 'object') {
+				if (Array.isArray(parsed.keyVocab) && parsed.keyVocab.length > 15) {
+					parsed.keyVocab = parsed.keyVocab.slice(0, 15);
+				}
+				if (parsed.quiz?.questions && Array.isArray(parsed.quiz.questions) && parsed.quiz.questions.length > 5) {
+					parsed.quiz.questions = parsed.quiz.questions.slice(0, 5);
+				}
+			}
+
 			// Try validation, with normalization if needed
 			try {
 				const validated = zodSchema.parse(parsed);

--- a/src/lib/utils/gemini-schemas.ts
+++ b/src/lib/utils/gemini-schemas.ts
@@ -111,7 +111,7 @@ export function createStorySchema(isConversation: boolean = false) {
 		title: titleSchema,
 		description: descriptionSchema,
 		sentences: z.array(createSentenceSchema(isConversation)).min(1),
-		keyVocab: z.array(textWithTranslationSchema).min(5).max(15).optional(), // Key vocabulary from the story (5-15 words)
+		keyVocab: z.array(textWithTranslationSchema).min(1).max(30).optional(),
 		quiz: z.object({
 			questions: z.array(quizQuestionSchema).min(3).max(5) // Short quiz with 3-5 questions
 		}).optional()

--- a/src/routes/api/create-story-darija/+server.ts
+++ b/src/routes/api/create-story-darija/+server.ts
@@ -463,23 +463,23 @@ Dialect flavor: mix of Arabic, Berber, and French loanwords — e.g., الطوم
 		}
 	}
 
-	// Map difficulty levels to descriptions
+	// Map difficulty levels to descriptions (includes target words-per-sentence)
 	const getDifficultyDescription = (level: string): string => {
 		switch (level.toLowerCase()) {
 			case 'a1':
-				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures';
+				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures. Each sentence MUST be around 8 words or fewer.';
 			case 'a2':
-				return 'A2 (Elementary) - Use elementary vocabulary with slightly more complex sentences';
+				return 'A2 (Elementary) - Use elementary vocabulary with slightly more complex sentences. Each sentence MUST be around 10 words or fewer.';
 			case 'b1':
-				return 'B1 (Intermediate) - Use intermediate vocabulary and varied sentence structures';
+				return 'B1 (Intermediate) - Use intermediate vocabulary and varied sentence structures. Each sentence should be around 12 words.';
 			case 'b2':
-				return 'B2 (Upper Intermediate) - Use upper intermediate vocabulary with complex sentence structures';
+				return 'B2 (Upper Intermediate) - Use upper intermediate vocabulary with complex sentence structures. Each sentence should be around 14 words.';
 			case 'c1':
-				return 'C1 (Advanced) - Use advanced vocabulary and sophisticated sentence structures';
+				return 'C1 (Advanced) - Use advanced vocabulary and sophisticated sentence structures. Each sentence should be around 16 words.';
 			case 'c2':
-				return 'C2 (Proficient) - Use proficient-level vocabulary and highly complex sentence structures';
+				return 'C2 (Proficient) - Use proficient-level vocabulary and highly complex sentence structures. Each sentence should be around 20 words.';
 			default:
-				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures';
+				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures. Each sentence MUST be around 8 words or fewer.';
 		}
 	};
 

--- a/src/routes/api/create-story-egyptian/+server.ts
+++ b/src/routes/api/create-story-egyptian/+server.ts
@@ -495,23 +495,23 @@ Dialect flavor words: وش، زين، هيه، عيل، وايد، كذا، لي
 		}
 	}
 
-	// Map difficulty levels to descriptions
+	// Map difficulty levels to descriptions (includes target words-per-sentence)
 	const getDifficultyDescription = (level: string): string => {
 		switch (level.toLowerCase()) {
 			case 'a1':
-				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures';
+				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures. Each sentence MUST be around 8 words or fewer.';
 			case 'a2':
-				return 'A2 (Elementary) - Use elementary vocabulary with slightly more complex sentences';
+				return 'A2 (Elementary) - Use elementary vocabulary with slightly more complex sentences. Each sentence MUST be around 10 words or fewer.';
 			case 'b1':
-				return 'B1 (Intermediate) - Use intermediate vocabulary and varied sentence structures';
+				return 'B1 (Intermediate) - Use intermediate vocabulary and varied sentence structures. Each sentence should be around 12 words.';
 			case 'b2':
-				return 'B2 (Upper Intermediate) - Use upper intermediate vocabulary with complex sentence structures';
+				return 'B2 (Upper Intermediate) - Use upper intermediate vocabulary with complex sentence structures. Each sentence should be around 14 words.';
 			case 'c1':
-				return 'C1 (Advanced) - Use advanced vocabulary and sophisticated sentence structures';
+				return 'C1 (Advanced) - Use advanced vocabulary and sophisticated sentence structures. Each sentence should be around 16 words.';
 			case 'c2':
-				return 'C2 (Proficient) - Use proficient-level vocabulary and highly complex sentence structures';
+				return 'C2 (Proficient) - Use proficient-level vocabulary and highly complex sentence structures. Each sentence should be around 20 words.';
 			default:
-				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures';
+				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures. Each sentence MUST be around 8 words or fewer.';
 		}
 	};
 

--- a/src/routes/api/create-story/+server.ts
+++ b/src/routes/api/create-story/+server.ts
@@ -248,23 +248,23 @@ Dialect flavor: mix of Arabic, Berber, and French loanwords — e.g., الطوم
 		}
 	}
 
-	// Map difficulty levels to descriptions
+	// Map difficulty levels to descriptions (includes target words-per-sentence)
 	const getDifficultyDescription = (level: string): string => {
 		switch (level.toLowerCase()) {
 			case 'a1':
-				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures';
+				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures. Each sentence MUST be around 8 words or fewer.';
 			case 'a2':
-				return 'A2 (Elementary) - Use elementary vocabulary with slightly more complex sentences';
+				return 'A2 (Elementary) - Use elementary vocabulary with slightly more complex sentences. Each sentence MUST be around 10 words or fewer.';
 			case 'b1':
-				return 'B1 (Intermediate) - Use intermediate vocabulary and varied sentence structures';
+				return 'B1 (Intermediate) - Use intermediate vocabulary and varied sentence structures. Each sentence should be around 12 words.';
 			case 'b2':
-				return 'B2 (Upper Intermediate) - Use upper intermediate vocabulary with complex sentence structures';
+				return 'B2 (Upper Intermediate) - Use upper intermediate vocabulary with complex sentence structures. Each sentence should be around 14 words.';
 			case 'c1':
-				return 'C1 (Advanced) - Use advanced vocabulary and sophisticated sentence structures';
+				return 'C1 (Advanced) - Use advanced vocabulary and sophisticated sentence structures. Each sentence should be around 16 words.';
 			case 'c2':
-				return 'C2 (Proficient) - Use proficient-level vocabulary and highly complex sentence structures';
+				return 'C2 (Proficient) - Use proficient-level vocabulary and highly complex sentence structures. Each sentence should be around 20 words.';
 			default:
-				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures';
+				return 'A1 (Beginner) - Use very basic vocabulary and simple sentence structures. Each sentence MUST be around 8 words or fewer.';
 		}
 	};
 

--- a/src/routes/api/stories/+server.ts
+++ b/src/routes/api/stories/+server.ts
@@ -41,12 +41,14 @@ export const GET: RequestHandler = async ({ url }) => {
   const dialect = url.searchParams.get('dialect') || undefined;
   const difficulty = url.searchParams.get('difficulty') || undefined;
   const search = url.searchParams.get('search') || undefined;
+  const userId = url.searchParams.get('userId') || undefined;
 
   try {
     const result = await getStoriesPaginated(cursor, pageSize, {
       dialect,
       difficulty,
-      search
+      search,
+      userId
     });
 
     if (!result.success) {

--- a/src/routes/api/topic-story/+server.ts
+++ b/src/routes/api/topic-story/+server.ts
@@ -1,0 +1,32 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { supabase } from '$lib/supabaseClient';
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	const { sessionId, user } = await locals?.auth?.validate() || {};
+	if (!sessionId || !user) {
+		return error(401, { message: 'Unauthorized' });
+	}
+
+	const { topicId, storyId } = await request.json();
+	if (!topicId || !storyId) {
+		return error(400, { message: 'topicId and storyId are required' });
+	}
+
+	const id = `${user.id}-${topicId}`;
+	const now = Date.now();
+
+	const { error: dbError } = await supabase
+		.from('user_topic_story')
+		.upsert(
+			{ id, user_id: user.id, topic_id: topicId, story_id: storyId, created_at: now },
+			{ onConflict: 'user_id,topic_id' }
+		);
+
+	if (dbError) {
+		console.error('Error saving topic story:', dbError);
+		return error(500, { message: 'Failed to save topic story' });
+	}
+
+	return json({ success: true });
+};

--- a/src/routes/generated_story/[id]/+page.svelte
+++ b/src/routes/generated_story/[id]/+page.svelte
@@ -15,7 +15,20 @@
   import AudioButton from '$lib/components/AudioButton.svelte';
   import PaywallModal from '$lib/components/PaywallModal.svelte';
   let isPaywallOpen = $state(false);
+  let savedWords = $state<Set<string>>(new Set());
+
+  // Fetch the user's saved words client-side and build a normalised Set for O(1) lookup
+  $effect(() => {
+    const userId = data.userId;
+    if (!userId) return;
+    fetchUserReviewWords(userId, 'all').then((words) => {
+      savedWords = new Set(
+        words.map((w) => w.arabic.replace(/[،,؟!.;:)(؛]/g, '').trim())
+      );
+    });
+  });
   import ArabicWordDisplay from '$lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte';
+  import { fetchUserReviewWords } from '$lib/helpers/fetch-review-words';
   import StoryAudioButton from '$lib/components/StoryAudioButton.svelte';
   import InlineAudioButton from '$lib/components/InlineAudioButton.svelte';
   import { goto } from '$app/navigation';
@@ -624,6 +637,7 @@
           showEnglish={sentenceEnglish}
           showTransliteration={sentenceTransliteration}
           showTashkeel={sentenceTashkeel}
+          {savedWords}
         />
 
         <!-- Footer with sentence number, per-sentence toggles, and audio -->

--- a/src/routes/stories/+page.server.ts
+++ b/src/routes/stories/+page.server.ts
@@ -47,14 +47,26 @@ export const load = async ({ parent, locals, url }) => {
     console.error('Error fetching stories:', storiesResult.error);
   }
 
-  // Fetch completed story IDs for the logged-in user
+  // Fetch completed story IDs and topic-story mappings in parallel
   let completedStoryIds: string[] = [];
+  let topicStoryMap: Record<string, string> = {};
   if (user?.id) {
-    const { data: completions } = await locals.supabase
-      .from('user_story_completion')
-      .select('story_id')
-      .eq('user_id', user.id);
-    completedStoryIds = completions?.map((c: any) => c.story_id) ?? [];
+    const [completionsRes, topicRes] = await Promise.all([
+      locals.supabase
+        .from('user_story_completion')
+        .select('story_id')
+        .eq('user_id', user.id),
+      locals.supabase
+        .from('user_topic_story')
+        .select('topic_id, story_id')
+        .eq('user_id', user.id)
+    ]);
+    completedStoryIds = completionsRes.data?.map((c: any) => c.story_id) ?? [];
+    if (topicRes.data) {
+      for (const m of topicRes.data) {
+        topicStoryMap[m.topic_id] = m.story_id;
+      }
+    }
   }
 
   const completedSet = new Set(completedStoryIds);
@@ -114,6 +126,7 @@ export const load = async ({ parent, locals, url }) => {
     hasMore,
     user,
     completedStoryIds,
+    topicStoryMap,
     initialDialect,
     resumeStory,
     recommendedStories,

--- a/src/routes/stories/+page.svelte
+++ b/src/routes/stories/+page.svelte
@@ -1,325 +1,321 @@
 <script lang="ts">
-	import { stories } from '$lib/constants/stories';
+	import { goto } from '$app/navigation';
 	import PaywallModal from '$lib/components/PaywallModal.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import AlphabetCycle from '$lib/components/AlphabetCycle.svelte';
 	import CreateStoryModal from '$lib/components/dialect-shared/story/components/CreateStoryModal.svelte';
-	import { BLOCKED_STORY_IDS } from '$lib/constants/stories/blocked';
+	import { fetchUserReviewWords } from '$lib/helpers/fetch-review-words';
+	import { START_HERE_TOPICS, ALL_TOPICS } from '$lib/constants/story-topics';
+	import type { StoryTopic } from '$lib/constants/story-topics';
 	import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
-	import { page } from '$app/stores';
 
 	let { data } = $props();
-	let shouldOpenCreate = $derived($page.url.searchParams.get('create') === 'true');
+
+	// ── Modal / paywall state ────────────────────────────────────────────────
 	let isModalOpen = $state(false);
-	let selectedDialect = $state(getDefaultDialect(data.user));
+	let isGeneratingModalOpen = $state(false);
+	let generatingTopicName = $state('');
 
+	// ── Topic card state ─────────────────────────────────────────────────────
+	let selectedDialect = $derived(getDefaultDialect(data.user));
 	let completedStoryIds = $derived(new Set<string>(data.completedStoryIds ?? []));
+	let generatingTopicId = $state<string | null>(null);
+	let topicStoryMap = $state<Record<string, string>>(data.topicStoryMap ?? {});
+	let generationError = $state<string | null>(null);
+	let allTopicsExpanded = $state(false);
 
-	// Search and filter state
-	let searchQuery = $state('');
-	let filterDialect = $state<string>(data.initialDialect);
-	let filterDifficulty = $state<string>('all');
-	let sortBy = $state<'newest' | 'oldest' | 'difficulty' | 'title'>('newest');
-
-	// Pagination state
+	// ── Lazy-loaded stories ──────────────────────────────────────────────────
 	let allLoadedStories = $state<any[]>([]);
-	let nextCursor = $state<string | null>(data.nextCursor || null);
-	let hasMore = $state(data.hasMore || false);
-	let isLoadingMore = $state(false);
-	let loadMoreTrigger: HTMLDivElement | null = $state(null);
+	let nextCursor = $state<string | null>(null);
+	let hasMore = $state(false);
+	let isLoadingStories = $state(false);
+	let storiesInitialized = $state(false);
+	let storiesSectionEl = $state<HTMLElement | null>(null);
+	let loadMoreTrigger = $state<HTMLElement | null>(null);
 
-	// Function to filter out incomplete sentences
-	function filterValidSentences(sentences: any[]) {
-		if (!Array.isArray(sentences)) return [];
-		return sentences.filter(sentence =>
-			sentence &&
-			sentence.arabic?.text &&
-			sentence.english?.text &&
-			sentence.transliteration?.text &&
-			typeof sentence.arabic.text === 'string' &&
-			typeof sentence.english.text === 'string' &&
-			typeof sentence.transliteration.text === 'string' &&
-			sentence.arabic.text.trim() !== '' &&
-			sentence.english.text.trim() !== '' &&
-			sentence.transliteration.text.trim() !== ''
-		);
-	}
+	// ── Story filters ────────────────────────────────────────────────────────
+	let filterDialect = $state('all');
+	let filterDifficulty = $state('all');
+	let filterByMe = $state(false);
 
-	// Transform initial server data
-	function transformStory(story: any) {
-		const storyBody = story.story_body;
-		const validSentences = filterValidSentences(storyBody?.sentences || []);
-		return {
-			id: story.id,
-			title: `${storyBody?.title?.english || ''} / ${storyBody?.title?.arabic || ''}`,
-			description: story.description,
-			createdAt: story.created_at,
-			difficulty: story.difficulty,
-			dialect: story.dialect,
-			dialectName: story.dialect_name,
-			length: validSentences.length
-		};
-	}
+	const dialectName: Record<string, string> = {
+		'egyptian-arabic': 'Egyptian Arabic',
+		'darija': 'Moroccan Darija',
+		'levantine': 'Levantine Arabic',
+		'fusha': 'Modern Standard Arabic',
+	};
 
-	// Initialize with server data
+	// Keep topicStoryMap in sync if server data changes (e.g. after navigation)
 	$effect(() => {
-		if (data.user_generated_stories && allLoadedStories.length === 0) {
-			allLoadedStories = data.user_generated_stories
-				.filter((story: any) => !BLOCKED_STORY_IDS.includes(story.id))
-				.map(transformStory);
-		}
+		if (data.topicStoryMap) topicStoryMap = { ...data.topicStoryMap };
 	});
 
-	// Fetch more stories from the API
-	async function loadMoreStories() {
-		if (isLoadingMore || !hasMore || !nextCursor) return;
-
-		isLoadingMore = true;
-
-		try {
-			const params = new URLSearchParams({
-				cursor: nextCursor,
-				pageSize: '12'
-			});
-
-			if (filterDialect !== 'all') {
-				params.set('dialect', filterDialect);
-			}
-			if (filterDifficulty !== 'all') {
-				params.set('difficulty', filterDifficulty);
-			}
-
-			const res = await fetch(`/api/stories?${params}`);
-			const result = await res.json();
-
-			if (result.stories) {
-				allLoadedStories = [...allLoadedStories, ...result.stories];
-				nextCursor = result.nextCursor;
-				hasMore = result.hasMore;
-			}
-		} catch (error) {
-			console.error('Error loading more stories:', error);
-		} finally {
-			isLoadingMore = false;
-		}
-	}
-
-	// Reset and reload when filters change (except sorting which is client-side)
-	async function resetAndReload() {
-		isLoadingMore = true;
-		allLoadedStories = [];
-		nextCursor = null;
-		hasMore = false;
-
-		try {
-			const params = new URLSearchParams({ pageSize: '12' });
-
-			if (filterDialect !== 'all') {
-				params.set('dialect', filterDialect);
-			}
-			if (filterDifficulty !== 'all') {
-				params.set('difficulty', filterDifficulty);
-			}
-
-			const res = await fetch(`/api/stories?${params}`);
-			const result = await res.json();
-
-			if (result.stories) {
-				allLoadedStories = result.stories;
-				nextCursor = result.nextCursor;
-				hasMore = result.hasMore;
-			}
-		} catch (error) {
-			console.error('Error reloading stories:', error);
-		} finally {
-			isLoadingMore = false;
-		}
-	}
-
-	// Handler for filter changes - called from select elements
-	function handleFilterChange() {
-		resetAndReload();
-	}
-
-	// Setup IntersectionObserver for infinite scroll
-	let observer: IntersectionObserver | null = null;
-
+	// ── IntersectionObserver: lazy-load stories section ──────────────────────
 	$effect(() => {
-		// Cleanup previous observer
-		if (observer) {
-			observer.disconnect();
-			observer = null;
-		}
-
-		if (!loadMoreTrigger) return;
-
-		observer = new IntersectionObserver(
+		const el = storiesSectionEl;
+		if (!el) return;
+		const obs = new IntersectionObserver(
 			(entries) => {
-				if (entries[0].isIntersecting && hasMore && !isLoadingMore) {
+				if (entries[0].isIntersecting) {
+					loadInitialStories();
+					obs.disconnect();
+				}
+			},
+			{ rootMargin: '400px' }
+		);
+		obs.observe(el);
+		return () => obs.disconnect();
+	});
+
+	// ── IntersectionObserver: infinite scroll ────────────────────────────────
+	$effect(() => {
+		const el = loadMoreTrigger;
+		if (!el) return;
+		const obs = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting && hasMore && !isLoadingStories) {
 					loadMoreStories();
 				}
 			},
 			{ rootMargin: '200px' }
 		);
+		obs.observe(el);
+		return () => obs.disconnect();
+	});
 
-		observer.observe(loadMoreTrigger);
+	// ── Story loading functions ──────────────────────────────────────────────
+	function buildStoryParams(extra?: Record<string, string>): URLSearchParams {
+		const params = new URLSearchParams({ pageSize: '12' });
+		if (filterDialect !== 'all') params.set('dialect', filterDialect);
+		if (filterDifficulty !== 'all') params.set('difficulty', filterDifficulty);
+		if (filterByMe && data.user?.id) params.set('userId', data.user.id);
+		if (extra) for (const [k, v] of Object.entries(extra)) params.set(k, v);
+		return params;
+	}
 
-		return () => {
-			if (observer) {
-				observer.disconnect();
+	async function loadInitialStories() {
+		if (storiesInitialized || isLoadingStories) return;
+		storiesInitialized = true;
+		isLoadingStories = true;
+		try {
+			const res = await fetch(`/api/stories?${buildStoryParams()}`);
+			const result = await res.json();
+			if (result.stories) {
+				allLoadedStories = result.stories;
+				nextCursor = result.nextCursor;
+				hasMore = result.hasMore;
 			}
-		};
-	});
-
-	// Derived: client-side filtering and sorting of loaded stories
-	let userGeneratedStories = $derived.by(() => {
-		let filtered = [...allLoadedStories];
-
-		// Client-side search filter
-		if (searchQuery.trim()) {
-			const query = searchQuery.toLowerCase();
-			filtered = filtered.filter(story =>
-				story.title?.toLowerCase().includes(query) ||
-				story.description?.toLowerCase().includes(query)
-			);
+		} catch {
+			// silently fail — stories section just stays empty
+		} finally {
+			isLoadingStories = false;
 		}
-
-		return filtered;
-	})
-
-	function openPaywallModal() {
-		isModalOpen = true;
 	}
 
-	function handleCloseModal() {
-		isModalOpen = false;
+	async function loadMoreStories() {
+		if (isLoadingStories || !hasMore || !nextCursor) return;
+		isLoadingStories = true;
+		try {
+			const res = await fetch(`/api/stories?${buildStoryParams({ cursor: nextCursor })}`);
+			const result = await res.json();
+			if (result.stories) {
+				allLoadedStories = [...allLoadedStories, ...result.stories];
+				nextCursor = result.nextCursor;
+				hasMore = result.hasMore;
+			}
+		} catch {
+			// silently fail
+		} finally {
+			isLoadingStories = false;
+		}
 	}
 
-	const dialectOptions = [
-		{ value: 'egyptian-arabic', label: 'Egyptian Arabic', emoji: '🇪🇬' },
-		{ value: 'fusha', label: 'Modern Standard Arabic', emoji: '📚' },
-		{ value: 'levantine', label: 'Levantine Arabic', emoji: '🇱🇧' },
-		{ value: 'darija', label: 'Moroccan Darija', emoji: '🇲🇦' },
-	];
+	async function resetStories() {
+		allLoadedStories = [];
+		nextCursor = null;
+		hasMore = false;
+		storiesInitialized = false;
+		isLoadingStories = false;
+		// Re-initialize immediately if section is already visible
+		await loadInitialStories();
+	}
 
-	const filterDialectOptions = [
-		{ value: 'all', label: 'All Dialects' },
-		...dialectOptions
-	];
+	// ── Helpers ──────────────────────────────────────────────────────────────
+	function mapProficiencyToDifficulty(level: string | null | undefined): string {
+		if (!level) return 'A2';
+		const map: Record<string, string> = { beginner: 'A2', intermediate: 'B1', advanced: 'B2' };
+		return map[level.toLowerCase()] ?? level ?? 'A2';
+	}
 
-	// Show featured (Egyptian Arabic) stories only when the filter matches
-	let showFeaturedStories = $derived(filterDialect === 'all' || filterDialect === 'egyptian-arabic');
+	function getSentenceCount(level: string | null | undefined): number {
+		if (!level) return 5;
+		const l = level.toLowerCase();
+		if (l === 'a1' || l === 'a2' || l === 'beginner') return 5;
+		if (l === 'b1' || l === 'b2' || l === 'intermediate') return 10;
+		if (l === 'c1' || l === 'c2' || l === 'advanced') return 15;
+		return 5;
+	}
 
-	const difficultyOptions = [
-		{ value: 'all', label: 'All Difficulties' },
-		{ value: 'beginner', label: 'Beginner' },
-		{ value: 'intermediate', label: 'Intermediate' },
-		{ value: 'advanced', label: 'Advanced' },
-	];
+	function getApiUrl(dialect: string): string {
+		if (dialect === 'egyptian-arabic') return '/api/create-story-egyptian';
+		if (dialect === 'darija') return '/api/create-story-darija';
+		return '/api/create-story';
+	}
 
-	// Difficulty order for sorting
-	const difficultyOrder: Record<string, number> = {
-		'beginner': 1,
-		'intermediate': 2,
-		'advanced': 3,
-	};
+	async function generateTopicStory(topic: StoryTopic) {
+		generatingTopicId = topic.id;
+		generatingTopicName = topic.name;
+		isGeneratingModalOpen = true;
+		generationError = null;
+		try {
+			const reviewWords = await fetchUserReviewWords(data.user.id, 'due-for-review');
+			const vocabularyWords = reviewWords
+				.slice(0, 15)
+				.map((w: { arabic: string; english: string }) => `${w.arabic} (${w.english})`)
+				.join(', ');
 
-	// Filter (search) and sort user-generated stories
-	// Note: dialect/difficulty filtering happens server-side, only search and sorting here
-	const filteredAndSortedStories = $derived.by(() => {
-		let filtered = [...userGeneratedStories];
+			const dialect = data.user?.target_dialect ?? 'egyptian-arabic';
+			const difficulty = mapProficiencyToDifficulty(data.user?.proficiency_level);
+			const apiUrl = getApiUrl(dialect);
 
-		// Sort (client-side sorting of loaded stories)
-		if (sortBy === 'newest') {
-			filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-		} else if (sortBy === 'oldest') {
-			filtered.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-		} else if (sortBy === 'difficulty') {
-			filtered.sort((a, b) => {
-				const aDiff = difficultyOrder[a.difficulty?.toLowerCase() || 'beginner'] || 0;
-				const bDiff = difficultyOrder[b.difficulty?.toLowerCase() || 'beginner'] || 0;
-				return aDiff - bDiff;
+			const res = await fetch(apiUrl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', accept: 'application/json' },
+				body: JSON.stringify({
+					description: topic.promptTemplate,
+					dialect,
+					difficulty,
+					option: difficulty, // Egyptian Arabic endpoint reads `option` for difficulty
+					sentenceCount: getSentenceCount(data.user?.proficiency_level),
+					storyType: 'story',
+					vocabularyWords: vocabularyWords || undefined,
+					useReviewWordsOnly: false,
+					learningTopics: [],
+					reviewWords: []
+				})
 			});
-		} else if (sortBy === 'title') {
-			filtered.sort((a, b) => (a.title || '').localeCompare(b.title || ''));
+
+			const result = await res.json();
+			if (!res.ok) throw new Error(result.error || 'Failed to generate story');
+
+			const storyId: string = result.storyId;
+			topicStoryMap = { ...topicStoryMap, [topic.id]: storyId };
+			// Persist mapping in DB (fire-and-forget — navigation happens immediately)
+			fetch('/api/topic-story', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ topicId: topic.id, storyId })
+			}).catch(() => {});
+			isGeneratingModalOpen = false;
+			await goto(`/generated_story/${storyId}`);
+		} catch (err) {
+			isGeneratingModalOpen = false;
+			generationError = err instanceof Error ? err.message : 'Something went wrong. Please try again.';
+		} finally {
+			generatingTopicId = null;
 		}
+	}
 
-		return filtered;
-	});
+	function isTopicLocked(topic: StoryTopic): boolean {
+		return topic.id !== START_HERE_TOPICS[0]?.id && !data.hasActiveSubscription;
+	}
 
-	// Get dialect badge color
+	function handleCardClick(topic: StoryTopic) {
+		if (!data.user) {
+			goto('/login');
+			return;
+		}
+		if (isTopicLocked(topic)) {
+			isModalOpen = true;
+			return;
+		}
+		const existingStoryId = topicStoryMap[topic.id];
+		if (existingStoryId) {
+			goto(`/generated_story/${existingStoryId}`);
+		} else {
+			generateTopicStory(topic);
+		}
+	}
+
+	function handleCloseModal() { isModalOpen = false; }
+
+	function getTopicState(topic: StoryTopic): 'completed' | 'in-progress' | 'generating' | 'default' {
+		if (generatingTopicId === topic.id) return 'generating';
+		const storyId = topicStoryMap[topic.id];
+		if (!storyId) return 'default';
+		if (completedStoryIds.has(storyId)) return 'completed';
+		return 'in-progress';
+	}
+
 	function getDialectBadgeColor(dialect: string) {
-		const colors = {
+		const colors: Record<string, string> = {
 			'egyptian-arabic': 'bg-tile-500 text-text-300',
 			'levantine': 'bg-orange-100 text-orange-800',
 			'darija': 'bg-green-100 text-green-800',
 			'fusha': 'bg-purple-100 text-purple-800',
 		};
-		return colors[dialect as keyof typeof colors] || 'bg-gray-100 text-gray-800';
+		return colors[dialect] || 'bg-gray-100 text-gray-800';
 	}
-
-	// Derive recommendation subtitle from user profile
-	let recommendationSubtitle = $derived.by(() => {
-		if (!data.user) return '';
-		const level = data.user.proficiency_level
-			? data.user.proficiency_level.charAt(0).toUpperCase() + data.user.proficiency_level.slice(1)
-			: null;
-		const dialectMap: Record<string, string> = {
-			'egyptian-arabic': 'Egyptian Arabic',
-			'levantine': 'Levantine Arabic',
-			'darija': 'Moroccan Darija',
-			'fusha': 'Modern Standard Arabic',
-		};
-		const dialectLabel = dialectMap[data.user.target_dialect] ?? data.user.target_dialect ?? null;
-		if (level && dialectLabel) return `${level} · ${dialectLabel}`;
-		if (level) return level;
-		if (dialectLabel) return dialectLabel;
-		return '';
-	});
 </script>
 
-<PaywallModal isOpen={isModalOpen} {handleCloseModal}></PaywallModal>
+<PaywallModal isOpen={isModalOpen} {handleCloseModal} />
+
+<!-- Generating Story Modal -->
+<Modal isOpen={isGeneratingModalOpen} handleCloseModal={() => {}} width="700px" height="fit-content">
+	<div class="p-6">
+		<div class="mx-auto my-8 flex flex-col items-center text-center gap-6 max-w-md">
+			<AlphabetCycle />
+			<div class="flex flex-col gap-3">
+				<h2 class="text-2xl font-bold text-text-300">
+					Generating {dialectName[data.user?.target_dialect ?? ''] ?? 'Arabic'} Story...
+				</h2>
+				<p class="text-text-200 text-lg">
+					Creating a story about <span class="font-semibold text-text-300">{generatingTopicName}</span> just for you.
+					<span class="block mt-2 text-sm opacity-75">This usually takes about 1–2 minutes.</span>
+				</p>
+			</div>
+			<div class="bg-tile-300 border border-tile-500 rounded-xl p-4 text-left w-full mt-2">
+				<div class="flex items-start gap-3">
+					<span class="text-2xl">💡</span>
+					<div>
+						<p class="font-bold text-text-300 text-sm mb-1">Pro Tip</p>
+						<p class="text-text-200 text-sm">
+							You can close this modal and continue using the app. We'll notify you when your story is ready!
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</Modal>
 
 <section class="px-3 mt-6 sm:px-8 max-w-7xl mx-auto">
-	<div class="text-left mb-12">
+	<!-- Header -->
+	<div class="text-left mb-8">
 		<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
 			<div>
-				<h1 class="text-3xl sm:text-4xl text-text-300 font-bold mb-2 tracking-tight">Stories</h1>
-				<p class="text-text-200 text-lg sm:text-xl leading-snug max-w-3xl">Improve your Arabic reading and listening comprehension skills with stories from all dialects.</p>
+				<h1 class="text-3xl sm:text-4xl text-text-300 font-bold mb-2 tracking-tight">
+					What would you like to read about?
+				</h1>
+				<p class="text-text-200 text-lg leading-snug max-w-2xl">
+					Pick a topic and we'll generate a short story in your dialect, weaving in words you're learning.
+				</p>
 			</div>
 			<div class="shrink-0">
-				<CreateStoryModal dialect={selectedDialect as any} data={data} initialOpen={shouldOpenCreate}></CreateStoryModal>
+				<CreateStoryModal dialect={selectedDialect as any} data={data} />
 			</div>
 		</div>
 	</div>
 
-	<!-- Recommended Story Hero Card -->
-	{#if data.recommendedStories?.length > 0}
-		{@const featuredStory = data.recommendedStories[0]}
-		<div class="mb-6">
-			<a
-				href={`/generated_story/${featuredStory.id}`}
-				class="group flex items-center justify-between bg-tile-400 border-2 border-tile-600 rounded-xl p-6 hover:bg-tile-500 hover:border-tile-500 transition-all duration-300 hover:-translate-y-1"
-			>
-				<div class="flex flex-col gap-2 min-w-0">
-					<span class="text-xs font-semibold uppercase tracking-widest text-text-200">Recommended Story for You</span>
-					<span class="text-xl sm:text-2xl font-bold text-text-300 group-hover:text-text-200 transition-colors leading-tight line-clamp-2">
-						{featuredStory.title}
-					</span>
-					<div class="flex items-center gap-2 mt-1 flex-wrap">
-						<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full {getDialectBadgeColor(featuredStory.dialect)}">
-							{featuredStory.dialectName}
-						</span>
-						{#if featuredStory.difficulty}
-							<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-tile-300 text-text-200 border border-tile-500">
-								{featuredStory.difficulty.toUpperCase()}
-							</span>
-						{/if}
-					</div>
-				</div>
-				<div class="shrink-0 ml-6 flex items-center gap-2 text-text-200 group-hover:text-text-300 transition-colors font-medium text-sm">
-					<span>Read Story</span>
-					<span class="text-lg">→</span>
-				</div>
-			</a>
+	<!-- Error Banner -->
+	{#if generationError}
+		<div class="mb-6 flex items-start gap-3 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-600">
+			<span class="shrink-0 text-base">⚠️</span>
+			<div>
+				<p class="font-medium">Couldn't generate story</p>
+				<p class="mt-0.5 opacity-80">{generationError}</p>
+			</div>
+			<button onclick={() => (generationError = null)} class="ml-auto shrink-0 text-red-400 hover:text-red-600">✕</button>
 		</div>
 	{/if}
 
@@ -343,7 +339,7 @@
 		</div>
 	{/if}
 
-	<!-- Continue Reading Card -->
+	<!-- Continue Reading -->
 	{#if data.resumeStory}
 		<div class="mb-8">
 			<a
@@ -364,194 +360,203 @@
 		</div>
 	{/if}
 
-	<!-- Recommended for You -->
-	{#if data.recommendedStories?.length > 0}
-		<div class="mb-12">
-			<div class="flex items-center gap-4 mb-2">
-				<h2 class="text-2xl sm:text-3xl text-text-300 font-bold">Recommended for You</h2>
-				<div class="h-0.5 bg-tile-500 flex-1 opacity-50 rounded-full"></div>
-			</div>
-			{#if recommendationSubtitle}
-				<p class="text-text-200 text-sm mb-6">{recommendationSubtitle}</p>
+	{#snippet topicCard(topic: StoryTopic)}
+		{@const state = getTopicState(topic)}
+		{@const locked = isTopicLocked(topic)}
+		<button
+			onclick={() => handleCardClick(topic)}
+			disabled={generatingTopicId !== null}
+			class="group/card relative flex flex-col items-center gap-2 rounded-2xl border border-tile-500 px-3 py-5 sm:px-4 sm:py-6 transition-all duration-200 w-full shadow-sm
+				{locked
+					? 'bg-tile-400/60 hover:bg-tile-400 hover:shadow-md'
+					: state === 'completed'
+						? 'bg-tile-400 border-green-500/40 shadow-green-500/5 hover:shadow-lg hover:shadow-green-500/10 hover:-translate-y-1'
+						: state === 'in-progress'
+							? 'bg-tile-400 border-tile-600 hover:shadow-lg hover:-translate-y-1'
+							: state === 'generating'
+								? 'bg-tile-500 border-tile-500 cursor-not-allowed'
+								: generatingTopicId !== null
+									? 'bg-tile-400 opacity-50 cursor-not-allowed'
+									: 'bg-tile-400 hover:bg-tile-500 hover:shadow-lg hover:border-tile-600 hover:-translate-y-1'}"
+		>
+			<!-- Badges -->
+			{#if locked}
+				<div class="absolute right-2.5 top-2.5 flex items-center justify-center w-6 h-6 rounded-full bg-tile-500/80 text-xs">🔒</div>
+			{:else if state === 'completed'}
+				<div class="absolute right-2.5 top-2.5 flex items-center justify-center w-6 h-6 rounded-full bg-green-500/15 border border-green-500/40">
+					<svg class="h-3.5 w-3.5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
+					</svg>
+				</div>
+			{:else if state === 'in-progress'}
+				<div class="absolute right-2.5 top-2.5 flex items-center justify-center w-6 h-6 rounded-full bg-tile-500 border border-tile-600">
+					<span class="text-text-200 text-xs font-bold">→</span>
+				</div>
 			{/if}
-			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-				{#each data.recommendedStories as story (story.id)}
-					<a href={`/generated_story/${story.id}`} class="group relative flex flex-col bg-tile-400 border-2 border-tile-600 rounded-xl p-8 shadow-lg hover:bg-tile-500 hover:border-tile-500 transition-all duration-300 hover:-translate-y-1">
-						<div class="flex justify-between items-start mb-4">
-							<div class="text-4xl">✨</div>
-							<div class="flex flex-col gap-1 items-end">
-								<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full {getDialectBadgeColor(story.dialect)}">
-									{story.dialectName}
-								</span>
-								{#if story.difficulty}
-									<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-tile-300 text-text-200 border border-tile-500">
-										{story.difficulty.toUpperCase()}
-									</span>
-								{/if}
-							</div>
-						</div>
-						<h3 class="text-2xl font-bold text-text-300 mb-3 group-hover:text-text-200 transition-colors leading-tight line-clamp-2">
-							{story.title}
-						</h3>
-						<div class="flex-grow"></div>
-					</a>
+
+			<!-- Generating overlay -->
+			{#if state === 'generating'}
+				<div class="absolute inset-0 rounded-2xl bg-tile-400/80 backdrop-blur-sm flex flex-col items-center justify-center gap-2 z-10">
+					<svg class="animate-spin h-6 w-6 text-text-200" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+					</svg>
+					<span class="text-xs text-text-200 font-medium">Generating...</span>
+				</div>
+			{/if}
+
+			<!-- Emoji with circle background -->
+			<div class="flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 rounded-full bg-tile-300/60 group-hover/card:bg-tile-300 transition-colors
+				{locked ? 'grayscale' : ''}"
+			>
+				<span class="text-2xl sm:text-3xl leading-none">{topic.emoji}</span>
+			</div>
+
+			<!-- Label -->
+			<span class="text-xs sm:text-sm font-semibold text-text-300 text-center leading-tight mt-0.5
+				{locked ? 'opacity-60' : ''}"
+			>
+				{topic.name}
+			</span>
+		</button>
+	{/snippet}
+
+	<!-- Start Here -->
+	<div class="mb-12">
+		<div class="flex items-center gap-4 mb-6">
+			<h2 class="text-2xl sm:text-3xl text-text-300 font-bold whitespace-nowrap">Start Here</h2>
+			<div class="h-0.5 bg-tile-500 flex-1 opacity-50 rounded-full"></div>
+		</div>
+		<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4">
+			{#each START_HERE_TOPICS as topic (topic.id)}
+				{@render topicCard(topic)}
+			{/each}
+		</div>
+	</div>
+
+	<!-- All Topics (collapsed by default) -->
+	<div class="mb-12">
+		<div class="flex items-center gap-4 mb-6">
+			<h2 class="text-2xl sm:text-3xl text-text-300 font-bold whitespace-nowrap">All Topics</h2>
+			<div class="h-0.5 bg-tile-500 flex-1 opacity-50 rounded-full"></div>
+			<button
+				onclick={() => (allTopicsExpanded = !allTopicsExpanded)}
+				class="shrink-0 flex items-center gap-1.5 text-sm font-medium text-text-200 hover:text-text-300 transition-colors px-3 py-1.5 rounded-lg border border-tile-500 hover:border-tile-600 bg-tile-400 hover:bg-tile-500"
+			>
+				{#if allTopicsExpanded}
+					Show Less <span>↑</span>
+				{:else}
+					Show All <span>↓</span>
+				{/if}
+			</button>
+		</div>
+		{#if allTopicsExpanded}
+			<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4">
+				{#each ALL_TOPICS as topic (topic.id)}
+					{@render topicCard(topic)}
 				{/each}
 			</div>
-		</div>
-	{/if}
+		{/if}
+	</div>
 
-	<!-- All Stories -->
-	<div>
-		<div class="flex items-center gap-4 mb-8">
-			<h2 class="text-2xl sm:text-3xl text-text-300 font-bold">Stories</h2>
+	<!-- Create Your Own -->
+	<div class="mb-12">
+		<div class="flex items-center gap-4 mb-6">
+			<h2 class="text-2xl sm:text-3xl text-text-300 font-bold whitespace-nowrap">Create Your Own</h2>
+			<div class="h-0.5 bg-tile-500 flex-1 opacity-50 rounded-full"></div>
+		</div>
+		<div class="rounded-xl border-2 border-dashed border-tile-500 bg-tile-400/40 p-8 flex flex-col sm:flex-row items-center justify-between gap-6">
+			<div>
+				<p class="text-text-300 font-semibold text-lg mb-1">Write your own story</p>
+				<p class="text-text-200 text-sm max-w-md">Choose your dialect, difficulty, grammar focus, and vocabulary</p>
+			</div>
+			<div class="shrink-0">
+				<CreateStoryModal dialect={selectedDialect as any} data={data} />
+			</div>
+		</div>
+	</div>
+
+	<!-- Stories (lazy-loaded when scrolled into view) -->
+	<div bind:this={storiesSectionEl} class="mb-12">
+		<div class="flex items-center gap-4 mb-6">
+			<h2 class="text-2xl sm:text-3xl text-text-300 font-bold whitespace-nowrap">Stories</h2>
 			<div class="h-0.5 bg-tile-500 flex-1 opacity-50 rounded-full"></div>
 		</div>
 
-		<!-- Search and Filter Controls -->
-		<div class="mb-6 space-y-4">
-			<!-- Search Bar -->
-			<div class="relative">
-				<input
-					type="text"
-					placeholder="Search stories by title or description..."
-					bind:value={searchQuery}
-					class="w-full pl-10 pr-4 py-3 border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600"
-				/>
-				<div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-					<svg class="h-5 w-5 text-text-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-					</svg>
-				</div>
+		<!-- Filters -->
+		<div class="flex flex-wrap items-end gap-3 mb-6">
+			<div class="flex-1 min-w-[140px]">
+				<label for="stories-dialect" class="block text-xs font-medium text-text-200 mb-1">Dialect</label>
+				<select
+					id="stories-dialect"
+					bind:value={filterDialect}
+					onchange={() => resetStories()}
+					class="w-full px-3 py-2 text-sm border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600"
+				>
+					<option value="all">All Dialects</option>
+					<option value="egyptian-arabic">Egyptian Arabic</option>
+					<option value="fusha">Modern Standard Arabic</option>
+					<option value="levantine">Levantine Arabic</option>
+					<option value="darija">Moroccan Darija</option>
+				</select>
 			</div>
-
-			<!-- Filters and Sort -->
-			<div class="flex flex-col sm:flex-row gap-4">
-				<!-- Dialect Filter -->
-				<div class="flex-1">
-					<label for="dialect-filter-stories" class="block text-sm font-medium text-text-200 mb-2">Filter by Dialect</label>
-					<select
-						id="dialect-filter-stories"
-						bind:value={filterDialect}
-						onchange={handleFilterChange}
-						class="w-full px-4 py-2.5 border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600 cursor-pointer"
-					>
-						{#each filterDialectOptions as option (option.value)}
-							<option value={option.value}>{option.label}</option>
-						{/each}
-					</select>
-				</div>
-
-				<!-- Difficulty Filter -->
-				<div class="flex-1">
-					<label for="difficulty-filter-stories" class="block text-sm font-medium text-text-200 mb-2">Filter by Difficulty</label>
-					<select
-						id="difficulty-filter-stories"
-						bind:value={filterDifficulty}
-						onchange={handleFilterChange}
-						class="w-full px-4 py-2.5 border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600 cursor-pointer"
-					>
-						{#each difficultyOptions as option (option.value)}
-							<option value={option.value}>{option.label}</option>
-						{/each}
-					</select>
-				</div>
-
-				<!-- Sort -->
-				<div class="flex-1">
-					<label for="sort-filter-stories" class="block text-sm font-medium text-text-200 mb-2">Sort By</label>
-					<select
-						id="sort-filter-stories"
-						bind:value={sortBy}
-						class="w-full px-4 py-2.5 border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600 cursor-pointer"
-					>
-						<option value="newest">Newest First</option>
-						<option value="oldest">Oldest First</option>
-						<option value="difficulty">Difficulty (Easy → Hard)</option>
-						<option value="title">Title (A-Z)</option>
-					</select>
-				</div>
+			<div class="flex-1 min-w-[140px]">
+				<label for="stories-difficulty" class="block text-xs font-medium text-text-200 mb-1">Difficulty</label>
+				<select
+					id="stories-difficulty"
+					bind:value={filterDifficulty}
+					onchange={() => resetStories()}
+					class="w-full px-3 py-2 text-sm border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600"
+				>
+					<option value="all">All Levels</option>
+					<option value="a1">A1</option>
+					<option value="a2">A2</option>
+					<option value="b1">B1</option>
+					<option value="b2">B2</option>
+					<option value="c1">C1</option>
+					<option value="c2">C2</option>
+				</select>
 			</div>
-
-			<!-- Results Count -->
-			<div class="text-sm text-text-200">
-				{#if hasMore}
-					Showing {filteredAndSortedStories.length}+ stories
-				{:else}
-					Showing {filteredAndSortedStories.length} stories
-				{/if}
-			</div>
+			{#if data.user}
+				<button
+					onclick={() => { filterByMe = !filterByMe; resetStories(); }}
+					class="px-4 py-2 text-sm font-medium rounded-lg border transition-colors
+						{filterByMe
+							? 'bg-tile-600 border-tile-600 text-text-300'
+							: 'bg-tile-300 border-tile-500 text-text-200 hover:bg-tile-400 hover:border-tile-600'}"
+				>
+					By Me
+				</button>
+			{/if}
 		</div>
 
-		{#if allLoadedStories.length === 0 && !showFeaturedStories && !isLoadingMore}
+		{#if !storiesInitialized}
+			<!-- Placeholder height so IntersectionObserver fires when user scrolls near -->
+			<div class="h-32 flex items-center justify-center">
+				<span class="text-text-200 text-sm opacity-50">Scroll to load stories</span>
+			</div>
+		{:else if isLoadingStories && allLoadedStories.length === 0}
+			<div class="flex justify-center py-16">
+				<svg class="animate-spin h-6 w-6 text-text-200" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+					<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+					<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+				</svg>
+			</div>
+		{:else if allLoadedStories.length === 0}
 			<div class="text-center py-16 bg-tile-400/30 border-2 border-dashed border-tile-500 rounded-xl">
 				<div class="text-6xl mb-4 opacity-50">✍️</div>
 				<p class="text-text-200 text-xl mb-2">No stories yet</p>
 				<p class="text-text-200 text-base opacity-70">Be the first to create one!</p>
 			</div>
-		{:else if filteredAndSortedStories.length === 0 && !showFeaturedStories && !isLoadingMore}
-			<div class="text-center py-12">
-				<p class="text-xl text-text-200">No stories found matching your criteria.</p>
-				<p class="text-text-200 mt-2">Try adjusting your search or filters.</p>
-			</div>
 		{:else}
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-				{#if showFeaturedStories}
-					{#each Object.entries(stories) as [key, value] (key)}
-						{#if value.isPaywalled && !data.hasActiveSubscription}
-							<button onclick={openPaywallModal} class="group flex flex-col bg-tile-400 border-2 border-tile-600 rounded-xl p-8 shadow-lg hover:bg-tile-500 hover:border-tile-500 transition-all duration-300 hover:-translate-y-1 text-left w-full h-full">
-								<div class="flex justify-between items-start mb-4">
-									<div class="text-4xl">🔒</div>
-									<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-tile-500 text-text-300">
-										Egyptian Arabic
-									</span>
-								</div>
-
-								<h3 class="text-2xl font-bold text-text-300 mb-3 group-hover:text-text-200 transition-colors leading-tight">
-									{value.story.title.english}
-								</h3>
-
-								<p class="text-text-200 text-base leading-relaxed opacity-90 group-hover:opacity-100 mb-4 line-clamp-3 flex-grow">
-									{value.description}
-								</p>
-
-								<div class="flex items-center gap-4 pt-4 border-t border-tile-500/50 mt-auto text-sm text-text-200 font-medium opacity-80">
-									<div class="flex items-center gap-1.5">
-										<span>📝</span>
-										<span>{value.story.sentences.length} Sentences</span>
-									</div>
-								</div>
-							</button>
-						{:else}
-							<a href={`/egyptian-arabic/stories/${key}`} class="group flex flex-col bg-tile-400 border-2 border-tile-600 rounded-xl p-8 shadow-lg hover:bg-tile-500 hover:border-tile-500 transition-all duration-300 hover:-translate-y-1">
-								<div class="flex justify-between items-start mb-4">
-									<div class="text-4xl">📖</div>
-									<span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-tile-500 text-text-300">
-										Egyptian Arabic
-									</span>
-								</div>
-
-								<h3 class="text-2xl font-bold text-text-300 mb-3 group-hover:text-text-200 transition-colors leading-tight">
-									{value.story.title.english}
-								</h3>
-
-								<p class="text-text-200 text-base leading-relaxed opacity-90 group-hover:opacity-100 mb-4 line-clamp-3 flex-grow">
-									{value.description}
-								</p>
-
-								<div class="flex items-center gap-4 pt-4 border-t border-tile-500/50 mt-auto text-sm text-text-200 font-medium opacity-80">
-									<div class="flex items-center gap-1.5">
-										<span>📝</span>
-										<span>{value.story.sentences.length} Sentences</span>
-									</div>
-								</div>
-							</a>
-						{/if}
-					{/each}
-				{/if}
-				{#each filteredAndSortedStories as story (story.id)}
+				{#each allLoadedStories as story (story.id)}
 					{@const isCompleted = completedStoryIds.has(story.id)}
 					{@const canReadFull = data.hasActiveSubscription}
-					<a href={`/generated_story/${story.id}`} class="group relative flex flex-col bg-tile-400 border-2 rounded-xl p-8 shadow-lg hover:bg-tile-500 transition-all duration-300 hover:-translate-y-1 {isCompleted ? 'border-green-500/50 hover:border-green-500/80' : 'border-tile-600 hover:border-tile-500'}">
+					<a
+						href={`/generated_story/${story.id}`}
+						class="group relative flex flex-col bg-tile-400 border-2 rounded-xl p-8 shadow-lg hover:bg-tile-500 transition-all duration-300 hover:-translate-y-1 {isCompleted ? 'border-green-500/50 hover:border-green-500/80' : 'border-tile-600 hover:border-tile-500'}"
+					>
 						{#if isCompleted}
 							<div class="absolute right-3 top-3 flex items-center gap-1 rounded-full border border-green-500/40 bg-green-500/15 px-2 py-0.5 text-xs font-semibold text-green-600">
 								<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -573,13 +578,10 @@
 								{/if}
 							</div>
 						</div>
-
-						<h3 class="text-2xl font-bold text-text-300 mb-3 group-hover:text-text-200 transition-colors leading-tight line-clamp-2">
+						<h3 class="text-xl font-bold text-text-300 mb-3 group-hover:text-text-200 transition-colors leading-tight line-clamp-2">
 							{story.title}
 						</h3>
-
 						<div class="flex-grow"></div>
-
 						<div class="flex items-center gap-4 pt-4 border-t border-tile-500/50 mt-4 text-sm text-text-200 font-medium opacity-80">
 							<div class="flex items-center gap-1.5">
 								<span>📝</span>
@@ -590,9 +592,9 @@
 				{/each}
 			</div>
 
-			<!-- Infinite Scroll Trigger -->
+			<!-- Infinite scroll trigger -->
 			<div bind:this={loadMoreTrigger} class="py-8 flex justify-center">
-				{#if isLoadingMore}
+				{#if isLoadingStories}
 					<div class="flex items-center gap-3 text-text-200">
 						<svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
 							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -600,14 +602,7 @@
 						</svg>
 						<span>Loading more stories...</span>
 					</div>
-				{:else if hasMore}
-					<button
-						onclick={loadMoreStories}
-						class="px-6 py-3 bg-tile-500 hover:bg-tile-600 text-text-300 rounded-lg transition-colors font-medium"
-					>
-						Load More Stories
-					</button>
-				{:else if allLoadedStories.length > 0}
+				{:else if !hasMore}
 					<p class="text-text-200 text-sm">You've reached the end</p>
 				{/if}
 			</div>


### PR DESCRIPTION
## Summary
- Replaces the paginated story list at `/stories` with a topic-card grid (30 topics across "Start Here" and "All Topics" sections) that generates personalized stories on demand
- Stories are tailored per user: uses their dialect, proficiency-based difficulty, scaled sentence count (A1→5, B→10, C→15), and word-count-per-sentence targets (A1→8 words, C2→20 words)
- Due-for-review vocabulary words are automatically interspersed in generated stories via the existing `vocabularyWords` API param
- Topic→story mappings persisted server-side in a new `user_topic_story` table (requires DB migration — see below)
- Saved words from the user's vocabulary are highlighted in amber in the story reader (`ArabicWordDisplay`)
- Auth-gated topic cards; all but the first topic are paywalled for free users
- Lazy-loaded "Stories" section at the bottom with dialect, difficulty, and "By Me" filters + infinite scroll
- Fixes Gemini response parsing failures when `keyVocab` exceeds 15 items (truncates before Zod validation)

## DB Migration Required
Run this SQL against Supabase before deploying:
```sql
CREATE TABLE public.user_topic_story (
  id text NOT NULL,
  user_id text NOT NULL,
  topic_id text NOT NULL,
  story_id text NOT NULL,
  created_at bigint NOT NULL,
  CONSTRAINT user_topic_story_pkey PRIMARY KEY (id),
  CONSTRAINT user_topic_story_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id),
  CONSTRAINT user_topic_story_user_topic_unique UNIQUE (user_id, topic_id)
);
```

## Test plan
- [ ] Visit `/stories` — should see "Start Here" topic cards with emoji circles
- [ ] Click first topic (Greetings) as free user — should generate and redirect to story
- [ ] Click any other topic as free user — should show paywall modal
- [ ] Click topic as subscriber — should generate story at user's difficulty level
- [ ] Navigate back to `/stories` — topic card should show "Resume →" badge
- [ ] Complete a story — topic card should show green "✓" badge
- [ ] Open a generated story — saved words should appear with amber border/background
- [ ] Scroll to "Stories" section — should lazy-load and show filter controls
- [ ] Toggle "By Me" filter — should show only current user's stories
- [ ] Filter by dialect/difficulty — stories should update accordingly
- [ ] Log out → click any topic card → should redirect to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)