### PR TITLE
fix: prevent flip-card ghost render between review words

### DIFF
--- a/src/routes/review/components/ReviewCard.svelte
+++ b/src/routes/review/components/ReviewCard.svelte
@@ -133,12 +133,18 @@
   // Reset state when word changes
   $effect(() => {
     if (word) {
+      // Suppress the flip-back animation on word change so both faces can't
+      // briefly render together while the rotation is in flight.
+      if (flipCardInner) flipCardInner.style.transition = 'none';
       showAnswer = false;
       showHint = false;
       selectedDifficulty = null;
       isFlipping = false;
       clearSelection();
       clearArabicSelection();
+      requestAnimationFrame(() => {
+        if (flipCardInner) flipCardInner.style.transition = '';
+      });
     }
   });
 
@@ -731,6 +737,7 @@
     width: 100%;
     transition: transform 0.6s, min-height 0.3s ease;
     transform-style: preserve-3d;
+    will-change: transform;
   }
 
   .flip-card-inner.flipped {
@@ -746,6 +753,7 @@
 
   .flip-card-front {
     position: relative;
+    transform: translate3d(0, 0, 0);
   }
 
   .flip-card-back {
@@ -753,6 +761,6 @@
     top: 0;
     left: 0;
     right: 0;
-    transform: rotateY(180deg);
+    transform: rotateY(180deg) translate3d(0, 0, 0);
   }
 </style>


### PR DESCRIPTION
## Summary

- On `/review`, after grading a card (Easy/Medium/Hard), the next card sometimes rendered with **both faces visible at once** — the new English translation showed alongside the front-face buttons appearing mirrored bleeding through. Reproed on Pixel 8 / Firefox Android PWA.
- Root cause: the difficulty buttons have child transforms (`scale-110`, `scale-95`, etc.) that collapse the parent's `preserve-3d` context, so `backface-visibility: hidden` isn't honored during the 0.6s flip-back animation that fires when the word changes.
- Fix in `src/routes/review/components/ReviewCard.svelte`:
  1. **Snap, don't flip, on word change.** The `$effect` that resets card state now suppresses the `.flip-card-inner` transition for one frame, so word-to-word transitions reset to the front face instantly — no mid-flip window for both faces to composite.
  2. **GPU-layer the faces.** Added `will-change: transform` on `.flip-card-inner` and `translate3d(0, 0, 0)` on both faces so each becomes its own compositing layer and `backface-visibility: hidden` is honored across Firefox Android, iOS Safari, and Chromium. User-initiated "Reveal Translation" flip is hardened too.

## Test plan

- [ ] On Pixel 8 / Firefox Android PWA: open `/review`, reveal + grade several cards in a row, confirm no mirrored text or English bleed-through on incoming cards.
- [ ] Confirm the user-initiated "Reveal Translation" flip still animates smoothly and only shows one face at a time.
- [ ] Confirm "Forgot - Review Again" produces a clean transition.
- [ ] Sanity check on Chrome desktop that nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)