### PR TITLE
feat(tutor): beginner scenarios + level-aware reply hints

### DIFF
--- a/src/lib/constants/tutor-scenarios.ts
+++ b/src/lib/constants/tutor-scenarios.ts
@@ -1,0 +1,385 @@
+import type { Dialect } from '$lib/types';
+
+export interface ScenarioLine {
+  speaker: 'student' | 'other';
+  arabic: string;
+  transliteration: string;
+  english: string;
+}
+
+export interface ScenarioDialog {
+  otherRoleEnglish: string;
+  lines: ScenarioLine[];
+}
+
+export interface TutorScenario {
+  id: string;
+  title: string;
+  emoji: string;
+  description: string;
+  level: 'beginner';
+  dialogs: Partial<Record<Dialect, ScenarioDialog>>;
+}
+
+export const TUTOR_SCENARIOS: TutorScenario[] = [
+  {
+    id: 'introducing-yourself',
+    title: 'Introducing Yourself',
+    emoji: '👋',
+    description: 'Share your name and where you are from.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'New friend',
+        lines: [
+          { speaker: 'student', arabic: 'مرحبا، اسمي سارة.', transliteration: 'marhaba, ismi Sara.', english: "Hi, my name is Sara." },
+          { speaker: 'other', arabic: 'أهلًا سارة، تشرفنا. أنا أحمد.', transliteration: 'ahlan Sara, tsharrafna. ana Ahmad.', english: "Hi Sara, nice to meet you. I'm Ahmad." },
+          { speaker: 'student', arabic: 'أنا من كندا. وانت من وين؟', transliteration: 'ana min Canada. winta min wein?', english: "I'm from Canada. Where are you from?" },
+          { speaker: 'other', arabic: 'أنا من لبنان، من بيروت.', transliteration: 'ana min Lubnan, min Beirut.', english: "I'm from Lebanon, from Beirut." }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'New friend',
+        lines: [
+          { speaker: 'student', arabic: 'أهلاً، أنا اسمي سارة.', transliteration: 'ahlan, ana ismi Sara.', english: "Hi, my name is Sara." },
+          { speaker: 'other', arabic: 'أهلاً بيكي يا سارة. أنا أحمد.', transliteration: 'ahlan biki ya Sara. ana Ahmad.', english: "Hi Sara. I'm Ahmad." },
+          { speaker: 'student', arabic: 'أنا من كندا. انت منين؟', transliteration: 'ana min Canada. inta mineen?', english: "I'm from Canada. Where are you from?" },
+          { speaker: 'other', arabic: 'أنا من مصر، من القاهرة.', transliteration: 'ana min Masr, min al-Qahira.', english: "I'm from Egypt, from Cairo." }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'New friend',
+        lines: [
+          { speaker: 'student', arabic: 'مرحبًا، اسمي سارة.', transliteration: 'marhaban, ismi Sara.', english: "Hello, my name is Sara." },
+          { speaker: 'other', arabic: 'أهلًا بكِ يا سارة. أنا أحمد.', transliteration: 'ahlan biki ya Sara. ana Ahmad.', english: "Hello Sara. I am Ahmad." },
+          { speaker: 'student', arabic: 'أنا من كندا. من أين أنت؟', transliteration: 'ana min Canada. min ayna anta?', english: "I am from Canada. Where are you from?" },
+          { speaker: 'other', arabic: 'أنا من الأردن.', transliteration: 'ana min al-Urdun.', english: "I am from Jordan." }
+        ]
+      }
+    }
+  },
+  {
+    id: 'greetings',
+    title: 'Greetings & Goodbyes',
+    emoji: '🤝',
+    description: 'Say hello, ask how someone is, and say goodbye.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'student', arabic: 'مرحبا! كيفك؟', transliteration: 'marhaba! kifak?', english: 'Hi! How are you?' },
+          { speaker: 'other', arabic: 'الحمد لله، منيح. وانت؟', transliteration: 'al-hamdulillah, mneeh. winta?', english: "Thank God, I'm good. And you?" },
+          { speaker: 'student', arabic: 'أنا كمان منيح، شكرا.', transliteration: 'ana kaman mneeh, shukran.', english: "I'm also good, thanks." },
+          { speaker: 'other', arabic: 'يلا، باي! بشوفك بكرا.', transliteration: 'yalla, bye! bshufak bukra.', english: 'Okay, bye! See you tomorrow.' }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'student', arabic: 'أهلاً! إزيك؟', transliteration: 'ahlan! izzayyak?', english: 'Hi! How are you?' },
+          { speaker: 'other', arabic: 'الحمد لله، كويس. وانت؟', transliteration: 'al-hamdulillah, kwayyis. winta?', english: "Thank God, I'm good. And you?" },
+          { speaker: 'student', arabic: 'أنا كمان كويس، شكراً.', transliteration: 'ana kaman kwayyis, shukran.', english: "I'm also good, thanks." },
+          { speaker: 'other', arabic: 'تمام، مع السلامة!', transliteration: 'tamam, ma3a as-salama!', english: 'Okay, goodbye!' }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'student', arabic: 'السلام عليكم. كيف حالك؟', transliteration: 'as-salamu alaykum. kayfa haluk?', english: 'Peace be upon you. How are you?' },
+          { speaker: 'other', arabic: 'وعليكم السلام. أنا بخير، الحمد لله.', transliteration: 'wa alaykum as-salam. ana bikhair, al-hamdulillah.', english: "And upon you peace. I am well, thanks be to God." },
+          { speaker: 'student', arabic: 'الحمد لله. تشرفنا.', transliteration: 'al-hamdulillah. tasharrafna.', english: 'Thanks be to God. Nice to meet you.' },
+          { speaker: 'other', arabic: 'مع السلامة.', transliteration: 'ma3a as-salama.', english: 'Goodbye.' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'ordering-coffee',
+    title: 'Ordering at a Café',
+    emoji: '☕',
+    description: 'Order coffee or tea and pay the bill.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'Café server',
+        lines: [
+          { speaker: 'other', arabic: 'أهلين، شو بتحب تشرب؟', transliteration: 'ahlein, shu bithibb tishrab?', english: 'Hi, what would you like to drink?' },
+          { speaker: 'student', arabic: 'بدي قهوة من فضلك.', transliteration: 'biddi ahweh min fadlak.', english: "I'd like a coffee, please." },
+          { speaker: 'other', arabic: 'مع سكر؟', transliteration: 'ma3 sukkar?', english: 'With sugar?' },
+          { speaker: 'student', arabic: 'بدون سكر، شكراً.', transliteration: 'bidoon sukkar, shukran.', english: 'No sugar, thanks.' }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'Café server',
+        lines: [
+          { speaker: 'other', arabic: 'اتفضل، تحب تشرب إيه؟', transliteration: 'itfaddal, tihibb tishrab eih?', english: 'Welcome, what would you like to drink?' },
+          { speaker: 'student', arabic: 'عايز قهوة من فضلك.', transliteration: '3ayiz ahwa min fadlak.', english: 'I want a coffee, please.' },
+          { speaker: 'other', arabic: 'سكر؟', transliteration: 'sukkar?', english: 'Sugar?' },
+          { speaker: 'student', arabic: 'سكر قليل، شكراً.', transliteration: 'sukkar 2alil, shukran.', english: 'A little sugar, thanks.' }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'Café server',
+        lines: [
+          { speaker: 'other', arabic: 'مرحبًا، ماذا تودّ أن تشرب؟', transliteration: 'marhaban, matha tawadd an tashrab?', english: 'Hello, what would you like to drink?' },
+          { speaker: 'student', arabic: 'أريد قهوة من فضلك.', transliteration: 'ureed qahwa min fadlik.', english: 'I would like a coffee, please.' },
+          { speaker: 'other', arabic: 'مع السكر؟', transliteration: 'ma3a as-sukkar?', english: 'With sugar?' },
+          { speaker: 'student', arabic: 'بدون سكر، شكرًا لك.', transliteration: 'bidoon sukkar, shukran lak.', english: 'Without sugar, thank you.' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'asking-directions',
+    title: 'Asking for Directions',
+    emoji: '🗺️',
+    description: 'Ask how to get somewhere on the street.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'Passerby',
+        lines: [
+          { speaker: 'student', arabic: 'عفواً، وين المتحف؟', transliteration: '3afwan, wein al-mathaf?', english: 'Excuse me, where is the museum?' },
+          { speaker: 'other', arabic: 'دغري، وبعدين لف يمين.', transliteration: 'dughri, w-ba3dein liff yameen.', english: 'Straight ahead, then turn right.' },
+          { speaker: 'student', arabic: 'بعيد عن هون؟', transliteration: 'b3eed 3an hon?', english: 'Is it far from here?' },
+          { speaker: 'other', arabic: 'لا، قريب. خمس دقايق مشي.', transliteration: 'la, areeb. khamis daqayiq mashi.', english: "No, it's close. Five minutes walking." }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'Passerby',
+        lines: [
+          { speaker: 'student', arabic: 'لو سمحت، فين المتحف؟', transliteration: 'law samaht, fein al-mathaf?', english: 'Excuse me, where is the museum?' },
+          { speaker: 'other', arabic: 'على طول، وبعدين شمال.', transliteration: '3ala tool, w-ba3dein shimal.', english: 'Straight ahead, then left.' },
+          { speaker: 'student', arabic: 'بعيد من هنا؟', transliteration: 'b3eed min hena?', english: 'Is it far from here?' },
+          { speaker: 'other', arabic: 'لأ، قريب. عشر دقايق.', transliteration: 'la2, urayyib. 3ashar daqayi2.', english: "No, it's close. Ten minutes." }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'Passerby',
+        lines: [
+          { speaker: 'student', arabic: 'عفوًا، أين المتحف؟', transliteration: '3afwan, ayna al-math.haf?', english: 'Excuse me, where is the museum?' },
+          { speaker: 'other', arabic: 'إلى الأمام مباشرة ثم انعطف يمينًا.', transliteration: 'ila al-amam mubasharatan thumma in3atif yameenan.', english: 'Straight ahead, then turn right.' },
+          { speaker: 'student', arabic: 'هل هو بعيد من هنا؟', transliteration: 'hal huwa ba3eed min huna?', english: 'Is it far from here?' },
+          { speaker: 'other', arabic: 'لا، قريب. حوالي عشر دقائق.', transliteration: 'la, qareeb. hawali 3ashr daqa2iq.', english: "No, it's close. About ten minutes." }
+        ]
+      }
+    }
+  },
+  {
+    id: 'ordering-taxi',
+    title: 'Ordering a Taxi',
+    emoji: '🚖',
+    description: 'Tell the driver where to go and ask the price.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'Taxi driver',
+        lines: [
+          { speaker: 'student', arabic: 'مرحبا، بدي أروح ع المطار.', transliteration: 'marhaba, biddi aruh 3al-mataar.', english: 'Hi, I want to go to the airport.' },
+          { speaker: 'other', arabic: 'تفضل. الأجرة عشرين دولار.', transliteration: 'tfaddal. al-ujra 3ishreen dolar.', english: 'Get in. The fare is twenty dollars.' },
+          { speaker: 'student', arabic: 'كم بياخد الطريق؟', transliteration: 'kam byakhud at-tareeq?', english: 'How long does the trip take?' },
+          { speaker: 'other', arabic: 'حوالي نص ساعة.', transliteration: 'hawali nuss sa3a.', english: 'About half an hour.' }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'Taxi driver',
+        lines: [
+          { speaker: 'student', arabic: 'لو سمحت، أنا رايح المطار.', transliteration: 'law samaht, ana rayih al-mataar.', english: 'Excuse me, I am going to the airport.' },
+          { speaker: 'other', arabic: 'اتفضل. الأجرة مية جنيه.', transliteration: 'itfaddal. al-ugra meet ginih.', english: 'Get in. The fare is one hundred pounds.' },
+          { speaker: 'student', arabic: 'الطريق بياخد قد إيه؟', transliteration: 'at-taree2 byakhud add eih?', english: 'How long does the trip take?' },
+          { speaker: 'other', arabic: 'حوالي تلت ساعة.', transliteration: 'hawali tilt sa3a.', english: 'About forty minutes.' }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'Taxi driver',
+        lines: [
+          { speaker: 'student', arabic: 'مرحبًا، أريد الذهاب إلى المطار.', transliteration: 'marhaban, ureed adh-dhahab ila al-mataar.', english: 'Hello, I would like to go to the airport.' },
+          { speaker: 'other', arabic: 'تفضل. الأجرة عشرون دولارًا.', transliteration: 'tafaddal. al-ujra 3ishroon doolaran.', english: 'Please get in. The fare is twenty dollars.' },
+          { speaker: 'student', arabic: 'كم تستغرق الرحلة؟', transliteration: 'kam tastaghriq ar-rihla?', english: 'How long does the trip take?' },
+          { speaker: 'other', arabic: 'حوالي نصف ساعة.', transliteration: 'hawali nisf sa3a.', english: 'About half an hour.' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'asking-price',
+    title: 'Asking About Prices',
+    emoji: '💰',
+    description: 'Ask how much something costs at a shop.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'Shopkeeper',
+        lines: [
+          { speaker: 'student', arabic: 'قديش هاد؟', transliteration: 'addeesh had?', english: 'How much is this?' },
+          { speaker: 'other', arabic: 'بعشر دولار.', transliteration: 'b3ashar dolar.', english: 'Ten dollars.' },
+          { speaker: 'student', arabic: 'غالي شوي. ممكن أقل؟', transliteration: 'ghali shway. mumkin a2all?', english: "It's a bit expensive. Can it be less?" },
+          { speaker: 'other', arabic: 'تمانية، آخر سعر.', transliteration: 'tmaneh, akhir si3r.', english: 'Eight, final price.' }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'Shopkeeper',
+        lines: [
+          { speaker: 'student', arabic: 'بكام ده؟', transliteration: 'bikam da?', english: 'How much is this?' },
+          { speaker: 'other', arabic: 'بخمسين جنيه.', transliteration: 'bikhamseen ginih.', english: 'Fifty pounds.' },
+          { speaker: 'student', arabic: 'غالي شوية. ممكن أقل؟', transliteration: 'ghali shwayya. mumkin a2all?', english: "It's a bit expensive. Can it be less?" },
+          { speaker: 'other', arabic: 'أربعين، آخر كلام.', transliteration: 'arba3een, akhir kalam.', english: 'Forty, final word.' }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'Shopkeeper',
+        lines: [
+          { speaker: 'student', arabic: 'كم ثمن هذا؟', transliteration: 'kam thaman hadha?', english: 'How much does this cost?' },
+          { speaker: 'other', arabic: 'بعشرة دولارات.', transliteration: 'bi3ashrat doolaraat.', english: 'Ten dollars.' },
+          { speaker: 'student', arabic: 'غالٍ قليلًا. هل يمكن أن يكون أقل؟', transliteration: 'ghaalin qaleelan. hal yumkin an yakoon aqall?', english: 'A bit expensive. Could it be less?' },
+          { speaker: 'other', arabic: 'ثمانية، السعر النهائي.', transliteration: 'thamaaniya, as-si3r an-niha2i.', english: 'Eight, final price.' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'asking-for-help',
+    title: 'Asking for Help',
+    emoji: '🆘',
+    description: "Say you don't understand and ask for help.",
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'A helpful local',
+        lines: [
+          { speaker: 'student', arabic: 'عفواً، بقدر تساعدني؟', transliteration: '3afwan, ba2dar tsa3idni?', english: 'Excuse me, can you help me?' },
+          { speaker: 'other', arabic: 'أكيد، شو بدك؟', transliteration: 'akeed, shu biddak?', english: 'Sure, what do you need?' },
+          { speaker: 'student', arabic: 'أنا تايه. ما بفهم منيح.', transliteration: 'ana tayih. ma bifham mneeh.', english: "I'm lost. I don't understand well." },
+          { speaker: 'other', arabic: 'لا تقلق، بساعدك.', transliteration: 'la tiqlaq, bisa3dak.', english: "Don't worry, I'll help you." }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'A helpful local',
+        lines: [
+          { speaker: 'student', arabic: 'لو سمحت، ممكن تساعدني؟', transliteration: 'law samaht, mumkin tisa3idni?', english: 'Excuse me, can you help me?' },
+          { speaker: 'other', arabic: 'أكيد، عايز إيه؟', transliteration: 'akeed, 3ayiz eih?', english: 'Sure, what do you need?' },
+          { speaker: 'student', arabic: 'أنا تايه. مش فاهم كويس.', transliteration: 'ana tayih. mish fahim kwayyis.', english: "I'm lost. I don't understand well." },
+          { speaker: 'other', arabic: 'متقلقش، أنا هساعدك.', transliteration: 'matq2alaq.sh, ana hasa3dak.', english: "Don't worry, I'll help you." }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'A helpful local',
+        lines: [
+          { speaker: 'student', arabic: 'عفوًا، هل يمكنك أن تساعدني؟', transliteration: '3afwan, hal yumkinuka an tusa3idani?', english: 'Excuse me, can you help me?' },
+          { speaker: 'other', arabic: 'بالتأكيد، ماذا تحتاج؟', transliteration: 'bit-ta2keed, matha tahtaaj?', english: 'Of course, what do you need?' },
+          { speaker: 'student', arabic: 'أنا تائه. لا أفهم جيدًا.', transliteration: 'ana ta2ih. la afham jayyidan.', english: "I am lost. I don't understand well." },
+          { speaker: 'other', arabic: 'لا تقلق، سأساعدك.', transliteration: 'la taqlaq, sa-usa3iduk.', english: "Don't worry, I will help you." }
+        ]
+      }
+    }
+  },
+  {
+    id: 'talking-about-family',
+    title: 'Talking About Family',
+    emoji: '👨‍👩‍👧',
+    description: 'Talk about your family — brothers, sisters, parents.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'other', arabic: 'عندك إخوة؟', transliteration: '3indak ikhweh?', english: 'Do you have siblings?' },
+          { speaker: 'student', arabic: 'عندي أخ وأخت.', transliteration: '3indi akh w-ikht.', english: 'I have one brother and one sister.' },
+          { speaker: 'other', arabic: 'وين ساكنين؟', transliteration: 'wein sakneen?', english: 'Where do they live?' },
+          { speaker: 'student', arabic: 'ساكنين مع أهلي في كندا.', transliteration: 'sakneen ma3 ahli fi Canada.', english: 'They live with my parents in Canada.' }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'other', arabic: 'عندك إخوات؟', transliteration: '3andak ikhwaat?', english: 'Do you have siblings?' },
+          { speaker: 'student', arabic: 'عندي أخ وأخت.', transliteration: '3andi akh wi ukht.', english: 'I have a brother and a sister.' },
+          { speaker: 'other', arabic: 'ساكنين فين؟', transliteration: 'sakneen fein?', english: 'Where do they live?' },
+          { speaker: 'student', arabic: 'ساكنين مع أهلي في كندا.', transliteration: 'sakneen ma3 ahli fi Canada.', english: 'They live with my parents in Canada.' }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'other', arabic: 'هل لديك إخوة؟', transliteration: 'hal ladayka ikhwa?', english: 'Do you have siblings?' },
+          { speaker: 'student', arabic: 'لديّ أخ وأخت.', transliteration: 'ladayya akh wa-ukht.', english: 'I have a brother and a sister.' },
+          { speaker: 'other', arabic: 'أين يعيشون؟', transliteration: 'ayna ya3eeshoon?', english: 'Where do they live?' },
+          { speaker: 'student', arabic: 'يعيشون مع والديّ في كندا.', transliteration: 'ya3eeshoon ma3a walidayya fi Canada.', english: 'They live with my parents in Canada.' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'at-the-restaurant',
+    title: 'At the Restaurant',
+    emoji: '🍽️',
+    description: 'Order food and ask for the bill.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'Waiter',
+        lines: [
+          { speaker: 'other', arabic: 'شو بتحب تاكل اليوم؟', transliteration: 'shu bithibb takul al-yom?', english: 'What would you like to eat today?' },
+          { speaker: 'student', arabic: 'بدي شاورما دجاج، من فضلك.', transliteration: 'biddi shawarma djaj, min fadlak.', english: "I'd like chicken shawarma, please." },
+          { speaker: 'other', arabic: 'تحب تشرب شي؟', transliteration: 'tihibb tishrab shi?', english: 'Would you like to drink something?' },
+          { speaker: 'student', arabic: 'كاسة مي، شكراً. والحساب لو سمحت.', transliteration: 'kaaset mayy, shukran. wal-hsab law samaht.', english: 'A glass of water, thanks. And the bill, please.' }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'Waiter',
+        lines: [
+          { speaker: 'other', arabic: 'تحب تاكل إيه النهارده؟', transliteration: 'tihibb takul eih in-naharda?', english: 'What would you like to eat today?' },
+          { speaker: 'student', arabic: 'عايز كشري من فضلك.', transliteration: '3ayiz kushari min fadlak.', english: 'I want koshari, please.' },
+          { speaker: 'other', arabic: 'تشرب إيه؟', transliteration: 'tishrab eih?', english: 'What would you like to drink?' },
+          { speaker: 'student', arabic: 'مية، شكراً. والحساب لو سمحت.', transliteration: 'mayya, shukran. wal-hisab law samaht.', english: 'Water, thanks. And the bill, please.' }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'Waiter',
+        lines: [
+          { speaker: 'other', arabic: 'ماذا تودّ أن تأكل اليوم؟', transliteration: 'matha tawadd an ta2kul al-yawm?', english: 'What would you like to eat today?' },
+          { speaker: 'student', arabic: 'أريد دجاجًا مشويًا من فضلك.', transliteration: 'ureed dajaajan mashwiyyan min fadlik.', english: 'I would like grilled chicken, please.' },
+          { speaker: 'other', arabic: 'هل تودّ أن تشرب شيئًا؟', transliteration: 'hal tawadd an tashrab shay2an?', english: 'Would you like something to drink?' },
+          { speaker: 'student', arabic: 'كوب ماء من فضلك. والحساب لاحقًا.', transliteration: 'koob ma2 min fadlik. wal-hisaab lahiqan.', english: 'A glass of water, please. And the bill later.' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'telling-time',
+    title: 'Asking the Time',
+    emoji: '🕒',
+    description: 'Ask what time it is and answer about your day.',
+    level: 'beginner',
+    dialogs: {
+      'levantine': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'student', arabic: 'قديش الساعة هلق؟', transliteration: 'addeesh as-sa3a halla2?', english: 'What time is it now?' },
+          { speaker: 'other', arabic: 'الساعة تلاتة وربع.', transliteration: 'as-sa3a tlateh w-rub3.', english: "It's three fifteen." },
+          { speaker: 'student', arabic: 'يلا، لازم أروح. عندي شغل.', transliteration: 'yalla, lazim aruh. 3indi shughl.', english: 'Okay, I have to go. I have work.' },
+          { speaker: 'other', arabic: 'تمام، بشوفك بعدين.', transliteration: 'tamam, bshufak ba3dein.', english: 'Okay, see you later.' }
+        ]
+      },
+      'egyptian-arabic': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'student', arabic: 'الساعة كام دلوقتي؟', transliteration: 'as-sa3a kam dilwa2ti?', english: 'What time is it now?' },
+          { speaker: 'other', arabic: 'الساعة تلاتة وربع.', transliteration: 'as-sa3a talata w-rub3.', english: "It's three fifteen." },
+          { speaker: 'student', arabic: 'لازم أمشي، عندي شغل.', transliteration: 'lazim amshi, 3andi shoghl.', english: 'I have to go, I have work.' },
+          { speaker: 'other', arabic: 'تمام، أشوفك بعدين.', transliteration: 'tamam, ashufak ba3dein.', english: 'Okay, see you later.' }
+        ]
+      },
+      'fusha': {
+        otherRoleEnglish: 'A friend',
+        lines: [
+          { speaker: 'student', arabic: 'كم الساعة الآن؟', transliteration: 'kam as-sa3a al-2aan?', english: 'What time is it now?' },
+          { speaker: 'other', arabic: 'الساعة الثالثة والربع.', transliteration: 'as-sa3a ath-thalitha war-rub3.', english: "It's three fifteen." },
+          { speaker: 'student', arabic: 'يجب أن أذهب. لديّ عمل.', transliteration: 'yajib an adhhab. ladayya 3amal.', english: 'I must go. I have work.' },
+          { speaker: 'other', arabic: 'حسنًا، إلى اللقاء.', transliteration: 'hasanan, ila al-liqaa2.', english: 'Okay, goodbye.' }
+        ]
+      }
+    }
+  }
+];

--- a/src/routes/api/tutor-hint/+server.ts
+++ b/src/routes/api/tutor-hint/+server.ts
@@ -1,0 +1,119 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/private';
+import { GoogleGenAI } from '@google/genai';
+import { type Dialect } from '$lib/types/index';
+import { parseJsonFromGeminiResponse } from '$lib/utils/gemini-json-parser';
+import { textWithTranslationSchema } from '$lib/utils/gemini-schemas';
+import { generateContentWithRetry, GeminiApiError } from '$lib/utils/gemini-api-retry';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+type ChatMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+const dialectNames: Record<Dialect, string> = {
+  fusha: 'Modern Standard Arabic (Fusha)',
+  levantine: 'Levantine Arabic',
+  darija: 'Moroccan Darija',
+  'egyptian-arabic': 'Egyptian Arabic',
+  iraqi: 'Iraqi Arabic',
+  khaleeji: 'Khaleeji Arabic'
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+  try {
+    const apiKey = env['GEMINI_API_KEY'];
+    if (!apiKey) {
+      return error(500, { message: 'GEMINI_API_KEY is not configured' });
+    }
+
+    const {
+      dialect,
+      conversation,
+      scenarioTitle,
+      scenarioDescription,
+      otherRole,
+      proficiencyLevel
+    } = await request.json();
+
+    if (!dialect || !dialectNames[dialect as Dialect]) {
+      return error(400, { message: 'Invalid dialect' });
+    }
+
+    const ai = new GoogleGenAI({ apiKey });
+    const dialectName = dialectNames[dialect as Dialect];
+    const history: ChatMessage[] = Array.isArray(conversation) ? conversation.slice(-8) : [];
+    const level = (typeof proficiencyLevel === 'string' && proficiencyLevel.trim()) ? proficiencyLevel.trim() : 'A1';
+
+    const speakerLabel = otherRole && typeof otherRole === 'string' ? otherRole : 'Tutor';
+    const conversationContext = history.length
+      ? history.map((m) => `${m.role === 'user' ? 'Student' : speakerLabel}: ${m.content}`).join('\n')
+      : '(no messages yet)';
+
+    const scenarioBlock = scenarioTitle
+      ? `SCENARIO: "${scenarioTitle}"${scenarioDescription ? ` — ${scenarioDescription}` : ''}
+The student is roleplaying as themselves. The other party is "${speakerLabel}".`
+      : `FREE CONVERSATION (no scripted scenario). The student is chatting with their Arabic tutor.`;
+
+    const prompt = `You are helping an Arabic learner know what to say next in a conversation.
+
+${scenarioBlock}
+
+Target dialect: ${dialectName}.
+Student's proficiency level: ${level} (CEFR). Calibrate vocabulary and sentence length to this level.
+
+Recent conversation so far:
+${conversationContext}
+
+Generate the NEXT line the student could naturally say to continue the conversation, based on what ${speakerLabel} just said.
+
+Rules:
+- ONE short sentence in ${dialectName}, calibrated to level ${level}.
+- Sound natural, not robotic. Use everyday phrasing for ${dialectName}.
+- Do NOT repeat lines the student has already said.
+- If a name or place would be needed, leave a "___" blank for the student to fill in.
+- For A1/A2 keep it very short (3-7 words). For B1+ a fuller sentence is okay.
+
+Respond as JSON with this exact shape:
+{
+  "arabic": "...",
+  "transliteration": "...",
+  "english": "..."
+}`;
+
+    const schemaJson = zodToJsonSchema(textWithTranslationSchema, 'TextWithTranslation');
+
+    const response = await generateContentWithRetry(ai, {
+      model: 'gemini-2.5-flash',
+      contents: prompt,
+      // @ts-expect-error - generationConfig is valid but types may be outdated
+      generationConfig: {
+        temperature: 0.7,
+        maxOutputTokens: 250,
+        responseMimeType: 'application/json',
+        responseJsonSchema: schemaJson
+      }
+    });
+
+    const responseContent = response.text;
+    if (!responseContent) {
+      throw new Error('No response from Gemini');
+    }
+
+    const parsed = parseJsonFromGeminiResponse(responseContent, textWithTranslationSchema);
+
+    return json({
+      arabic: parsed.arabic,
+      transliteration: parsed.transliteration,
+      english: parsed.english
+    });
+  } catch (e) {
+    console.error('Tutor hint error:', e);
+    if (e instanceof GeminiApiError && e.is503) {
+      return error(503, { message: 'The AI model is currently overloaded. Please try again.' });
+    }
+    return error(500, { message: 'Failed to generate hint.' });
+  }
+};

--- a/src/routes/tutor/+page.svelte
+++ b/src/routes/tutor/+page.svelte
@@ -11,6 +11,7 @@
   import { type Dialect } from '$lib/types/index';
   import type { DialectComparisonSchema } from '$lib/utils/gemini-schemas';
   import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
+  import { TUTOR_SCENARIOS, type TutorScenario } from '$lib/constants/tutor-scenarios';
 
   let { data } = $props();
 
@@ -141,6 +142,134 @@
   let mode = $state<TutorMode>('conversation');
 
   let selectedDialect = $state<Dialect>(getDefaultDialect(data.user) as Dialect);
+
+  // Scenario picker state (beginner conversation starters)
+  interface HintData {
+    arabic: string;
+    transliteration: string;
+    english: string;
+  }
+  let activeScenarioContext = $state<TutorScenario | null>(null);
+  let hintsVisible = $state(true);
+  let currentHint = $state<HintData | null>(null);
+  let isLoadingHint = $state(false);
+
+  let scenariosForDialect = $derived(
+    TUTOR_SCENARIOS.filter((s) => s.dialogs[selectedDialect])
+  );
+
+  let activeScenarioDialog = $derived(
+    activeScenarioContext ? activeScenarioContext.dialogs[selectedDialect] ?? null : null
+  );
+
+  function startScenario(scenario: TutorScenario) {
+    const dialog = scenario.dialogs[selectedDialect];
+    if (!dialog) return;
+
+    activeScenarioContext = scenario;
+    hintsVisible = true;
+    currentHint = null;
+
+    // Seed the very first hint from the hardcoded scenario data: the first
+    // student line. After the student records and the AI replies, subsequent
+    // hints are generated dynamically based on the AI's response.
+    const firstStudentLine = dialog.lines.find((l) => l.speaker === 'student');
+    if (firstStudentLine) {
+      currentHint = {
+        arabic: firstStudentLine.arabic,
+        transliteration: firstStudentLine.transliteration,
+        english: firstStudentLine.english
+      };
+    }
+
+    // If the scenario opens with the other party speaking, seed the conversation
+    // with that line so the user has something to respond to.
+    if (dialog.lines[0]?.speaker === 'other') {
+      const opening = dialog.lines[0];
+      const seededMsg: ConversationMessage = {
+        id: 'scenario-seed-' + Date.now(),
+        type: 'tutor',
+        arabic: opening.arabic,
+        english: opening.english,
+        transliteration: opening.transliteration,
+        timestamp: new Date(),
+        showArabic: true,
+        showEnglish: true,
+        showTransliteration: true
+      };
+      conversation = [...conversation, seededMsg];
+      setTimeout(() => {
+        playTutorAudio(opening.arabic, selectedDialect);
+      }, 400);
+    }
+  }
+
+  function exitScenario() {
+    activeScenarioContext = null;
+    currentHint = null;
+    isLoadingHint = false;
+  }
+
+  function toggleHints() {
+    hintsVisible = !hintsVisible;
+  }
+
+  function buildScenarioPrimer(): { role: 'user' | 'assistant'; content: string }[] {
+    if (!activeScenarioContext || !activeScenarioDialog) return [];
+    const role = activeScenarioDialog.otherRoleEnglish;
+    return [
+      {
+        role: 'user',
+        content: `Let's roleplay this scenario: "${activeScenarioContext.title}". You play the role of ${role}. Reply in character, short and natural, in ${selectedDialect}. Keep it beginner-friendly.`
+      },
+      {
+        role: 'assistant',
+        content: `Okay, I'll play ${role}. Go ahead.`
+      }
+    ];
+  }
+
+  async function fetchNextHint() {
+    isLoadingHint = true;
+    try {
+      const history = conversation
+        .filter((m) => m.type === 'user' || m.type === 'tutor')
+        .map((m) => ({
+          role: m.type === 'user' ? ('user' as const) : ('assistant' as const),
+          content: m.arabic || m.english || ''
+        }))
+        .slice(-8);
+
+      const body: Record<string, unknown> = {
+        dialect: selectedDialect,
+        conversation: history,
+        proficiencyLevel: data.user?.proficiency_level || 'A1'
+      };
+      if (activeScenarioContext && activeScenarioDialog) {
+        body.scenarioTitle = activeScenarioContext.title;
+        body.scenarioDescription = activeScenarioContext.description;
+        body.otherRole = activeScenarioDialog.otherRoleEnglish;
+      }
+
+      const res = await fetch('/api/tutor-hint', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      if (!res.ok) throw new Error('Failed to fetch hint');
+      const json = await res.json();
+      currentHint = {
+        arabic: json.arabic,
+        transliteration: json.transliteration,
+        english: json.english
+      };
+    } catch (e) {
+      console.error('Failed to load hint:', e);
+      currentHint = null;
+    } finally {
+      isLoadingHint = false;
+    }
+  }
   let recording = $state(false);
   let recordingLanguage = $state<'ar' | 'en'>('ar');
   let mediaRecorder: MediaRecorder | null = $state(null);
@@ -433,6 +562,7 @@
     selectedDialect = dialect as Dialect;
     conversation = [];
     conversationId = null; // Reset for new dialect
+    exitScenario();
   }
 
   async function startRecording(language: 'ar' | 'en') {
@@ -507,7 +637,7 @@
       isGettingResponse = true;
 
       // Build history before adding the new user message
-      const conversationHistory = conversation
+      const recentHistory = conversation
         .filter(msg => msg.type === 'user' || msg.type === 'tutor')
         .map(msg => {
           if (msg.type === 'user') {
@@ -523,6 +653,9 @@
           }
         })
         .slice(-10);
+      // Prepend a roleplay primer if the user is in a guided scenario so the AI
+      // stays in character. The primer is never displayed in the UI.
+      const conversationHistory = [...buildScenarioPrimer(), ...recentHistory];
 
       // Show optimistic user message immediately with raw transcription
       const optimisticId = Date.now().toString();
@@ -611,7 +744,11 @@
       };
       conversation = [...conversation, tutorMsg];
       scrollToBottom();
-      
+
+      // After each tutor reply, generate a suggestion for what to say next.
+      // Calibrated to the student's proficiency level (and scenario, if active).
+      fetchNextHint();
+
       setTimeout(() => scrollToBottom(), 100);
 
       if (tutorData.arabic) {
@@ -734,6 +871,8 @@
     conversationId = null;
     showSummaryModal = false;
     summaryData = { summary: '', topics: [], vocabulary: [], insights: [] };
+    exitScenario();
+    currentHint = null;
   }
   
   function closeSummaryModal() {
@@ -1390,43 +1529,103 @@
       {:else}
         <!-- Conversation Mode Content -->
         <div class="bg-tile-400 border-2 border-tile-600 rounded-lg shadow-lg overflow-hidden h-full">
-          <div class="p-4 border-b border-tile-600 sticky top-0 bg-tile-400 z-10">
-            <div class="flex items-center justify-between">
+          <div class="border-b border-tile-600 sticky top-0 bg-tile-400 z-10">
+            <div class="p-4 flex items-center justify-between gap-3 flex-wrap">
               <h3 class="text-lg font-bold text-text-300 flex items-center gap-2">
                 <span>💬</span> Conversation
               </h3>
-              {#if conversation.length > 0}
-                <span class="px-3 py-1 bg-tile-500 rounded-full text-sm font-medium text-text-300">
-                  {conversation.length} message{conversation.length !== 1 ? 's' : ''}
-                </span>
-              {/if}
+              <div class="flex items-center gap-2">
+                {#if conversation.length > 0 && !activeScenarioContext}
+                  <button
+                    type="button"
+                    onclick={toggleHints}
+                    class="text-xs px-2.5 py-1 rounded-md font-medium bg-tile-500 hover:bg-tile-600 text-text-300 transition-colors"
+                    aria-pressed={hintsVisible}
+                    title="Toggle reply suggestions"
+                  >
+                    💡 {hintsVisible ? 'Hide hints' : 'Show hints'}
+                  </button>
+                {/if}
+                {#if conversation.length > 0}
+                  <span class="px-3 py-1 bg-tile-500 rounded-full text-sm font-medium text-text-300">
+                    {conversation.length} message{conversation.length !== 1 ? 's' : ''}
+                  </span>
+                {/if}
+              </div>
             </div>
+
+            {#if activeScenarioContext && activeScenarioDialog}
+              <div class="px-4 pb-3 -mt-1 flex items-center justify-between gap-2">
+                <div class="flex items-center gap-2 min-w-0">
+                  <span class="text-xl shrink-0">{activeScenarioContext.emoji}</span>
+                  <div class="min-w-0">
+                    <p class="text-xs font-semibold text-text-300 truncate">
+                      Practicing: {activeScenarioContext.title}
+                    </p>
+                    <p class="text-[11px] text-text-200 truncate">
+                      Tutor is playing: {activeScenarioDialog.otherRoleEnglish}
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-center gap-1.5 shrink-0">
+                  <button
+                    type="button"
+                    onclick={toggleHints}
+                    class="text-[11px] px-2 py-1 rounded-md font-medium bg-tile-500 hover:bg-tile-600 text-text-300 transition-colors"
+                    aria-pressed={hintsVisible}
+                  >
+                    {hintsVisible ? 'Hide hints' : 'Show hints'}
+                  </button>
+                  <button
+                    type="button"
+                    onclick={exitScenario}
+                    class="text-[11px] px-2 py-1 rounded-md font-medium bg-tile-500 hover:bg-tile-600 text-text-300 transition-colors"
+                  >
+                    Exit
+                  </button>
+                </div>
+              </div>
+            {/if}
           </div>
         
         <div
           bind:this={transcriptContainer}
           class="p-4 min-h-[500px] max-h-[calc(100vh-200px)] overflow-y-auto {conversationStarted ? 'pb-52 lg:pb-4' : ''}"
         >
-          {#if conversation.length === 0 && !isTranscribing && !isGettingResponse}
-            <div class="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
-              <div class="text-6xl mb-6">👋</div>
-              <h3 class="text-xl font-bold text-text-300 mb-3">Start a Conversation</h3>
+          {#if conversation.length === 0 && !activeScenarioContext && !isTranscribing && !isGettingResponse}
+            <div class="flex flex-col items-center justify-start h-full min-h-[400px] text-center py-6">
+              <div class="text-6xl mb-4">👋</div>
+              <h3 class="text-xl font-bold text-text-300 mb-2">Start a Conversation</h3>
               <p class="text-text-200 max-w-md leading-relaxed">
-                Click one of the recording buttons to begin speaking with your AI tutor. 
-                Your conversation will appear here.
+                Pick a beginner scenario below for guided practice, or use the recording
+                buttons to start free conversation with your AI tutor.
               </p>
-              <div class="mt-6 grid grid-cols-2 gap-4 max-w-sm">
-                <div class="p-4 bg-tile-300 rounded-lg border border-tile-500 text-center">
-                  <span class="text-2xl block mb-2">🗣️</span>
-                  <span class="text-sm font-medium text-text-300">Speak Arabic</span>
-                  <p class="text-xs text-text-200 mt-1">Practice conversation</p>
+
+              {#if scenariosForDialect.length > 0 && !activeScenarioContext}
+                <div class="w-full max-w-4xl mt-8">
+                  <div class="flex items-center justify-between mb-3 px-1">
+                    <h4 class="text-sm font-bold text-text-300 flex items-center gap-2">
+                      <span>🎯</span> Beginner Scenarios
+                    </h4>
+                    <span class="text-xs text-text-200">Tap a card to see example phrases</span>
+                  </div>
+                  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 text-left">
+                    {#each scenariosForDialect as scenario (scenario.id)}
+                      <button
+                        type="button"
+                        onclick={() => startScenario(scenario)}
+                        class="group flex items-start gap-3 p-4 bg-tile-300 rounded-xl border-2 border-tile-500 hover:bg-tile-400 hover:border-tile-600 hover:shadow-lg transition-all duration-200 text-left active:scale-95"
+                      >
+                        <span class="text-3xl shrink-0 transition-transform duration-200 group-hover:scale-110">{scenario.emoji}</span>
+                        <div class="min-w-0">
+                          <p class="text-sm font-semibold text-text-300 mb-1">{scenario.title}</p>
+                          <p class="text-xs text-text-200 leading-snug">{scenario.description}</p>
+                        </div>
+                      </button>
+                    {/each}
+                  </div>
                 </div>
-                <div class="p-4 bg-tile-300 rounded-lg border border-tile-500 text-center">
-                  <span class="text-2xl block mb-2">❓</span>
-                  <span class="text-sm font-medium text-text-300">Ask in English</span>
-                  <p class="text-xs text-text-200 mt-1">Get help & translations</p>
-                </div>
-              </div>
+              {/if}
             </div>
           {:else}
             <div class="space-y-4">
@@ -1649,7 +1848,30 @@
                     </div>
                 {/if}
               {/each}
-              
+
+              <!-- Reply hint: appears below the latest tutor message -->
+              {#if hintsVisible && (currentHint || isLoadingHint)}
+                <div class="flex">
+                  <div class="max-w-[90%] sm:max-w-[80%] bg-sky-500/10 border border-dashed border-sky-500/40 rounded-xl p-3 sm:p-4 ml-1">
+                    <div class="flex items-center justify-between gap-3 mb-1">
+                      <span class="text-[10px] font-bold uppercase tracking-wide text-sky-700">
+                        💡 Hint — try saying
+                      </span>
+                      {#if currentHint && !isLoadingHint}
+                        <AudioButton text={currentHint.arabic} dialect={selectedDialect} className="!p-1.5 !rounded-md bg-tile-500 hover:bg-tile-600" />
+                      {/if}
+                    </div>
+                    {#if isLoadingHint}
+                      <p class="text-xs text-text-200 italic">Thinking of a hint…</p>
+                    {:else if currentHint}
+                      <p class="text-lg sm:text-xl font-semibold text-text-300 leading-snug" dir="rtl">{currentHint.arabic}</p>
+                      <p class="text-xs sm:text-sm text-text-200 italic mt-0.5">{currentHint.transliteration}</p>
+                      <p class="text-xs sm:text-sm text-text-300 mt-0.5">{currentHint.english}</p>
+                    {/if}
+                  </div>
+                </div>
+              {/if}
+
               <!-- Loading States -->
               {#if isTranscribing}
                 <div class="bg-sky-500/10 border-2 border-sky-500/30 rounded-xl p-6 animate-pulse">


### PR DESCRIPTION
## Summary

Adds two beginner-friendly upgrades to `/tutor`:

### 1. Beginner Scenarios picker
- 10 scripted scenarios (Introducing Yourself, Greetings, Ordering at a Café, Asking for Directions, Ordering a Taxi, Asking About Prices, Asking for Help, Talking About Family, At the Restaurant, Asking the Time) — each with a 4-line example dialog in **Egyptian Arabic, Levantine, and Fusha**.
- Cards live in the empty state of the conversation column. Clicking one enters guided mode: a slim banner shows `Practicing: X / Tutor is playing: Y` with `Hide hints` and `Exit` controls.
- A hidden roleplay primer is prepended to the conversation history sent to `/api/tutor-chat` so the AI stays in character (taxi driver, café server, etc.). The primer is never rendered in the UI.
- Scenarios whose dialog opens with the "other" speaker auto-seed that line as a tutor message + auto-play TTS.

### 2. Level-aware reply hints (universal)
- New endpoint **`/api/tutor-hint`** uses Gemini 2.5 Flash to suggest a natural next student line based on the tutor's last reply, the recent history (up to 8 turns), the dialect, and the user's CEFR `proficiencyLevel`. Returns `{ arabic, transliteration, english }`.
- Hint card renders inside the conversation flow, **directly below the latest tutor message**, with a subtle dashed sky border, an audio button, and a "Thinking of a hint…" placeholder while loading.
- First scenario hint is hardcoded from `tutor-scenarios.ts`; every subsequent hint is generated dynamically.
- Hints **also work outside scenarios** — calibrated to level only — with a `💡 Hide hints / Show hints` toggle in the conversation header.

## Files
- `src/lib/constants/tutor-scenarios.ts` (new)
- `src/routes/api/tutor-hint/+server.ts` (new)
- `src/routes/tutor/+page.svelte` (wiring)

## Test plan
- [ ] Open `/tutor` in conversation mode → see 10 scenario cards in the empty state for the selected dialect.
- [ ] Click a scenario that opens with the other speaker (e.g. Ordering at a Café, Egyptian) → tutor's opening line is seeded + TTS plays + hint card shows the student's first line below it.
- [ ] Click a scenario that opens with the student (e.g. Ordering a Taxi, Egyptian) → hint card shows the student's first line immediately, no seeded message.
- [ ] Switch dialect → scenario state resets cleanly.
- [ ] Record a reply (mic) → AI replies in character → new hint generated dynamically below the new tutor message.
- [ ] Toggle `Hide hints` / `Show hints` → hint card hides/shows; toggle persists.
- [ ] Click `Exit` → banner gone, picker re-appears, conversation continues as free chat.
- [ ] In **free conversation** (no scenario): record a question → AI replies → a hint appears below it, calibrated to your profile's proficiency level. Toggle works.
- [ ] Quick API smoke: `POST /api/tutor-hint` with no scenario + `A1` returns a 2-3 word reply; same call with `B1` returns a fuller sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)