### PR TITLE
feat(lessons): unlock all structured lessons for subscribers

### DIFF
--- a/src/routes/lessons/structured/[dialect]/+page.svelte
+++ b/src/routes/lessons/structured/[dialect]/+page.svelte
@@ -45,14 +45,14 @@
 				if (!exists) {
 					// Lesson doesn't exist yet
 					status = 'locked';
-				} else if (isWhitelisted) {
-					// Whitelisted users: all existing lessons are unlocked
+				} else if (isWhitelisted || isSubscribed) {
+					// Whitelisted and subscribed users: all existing lessons are unlocked
 					if (isCompleted) {
 						status = 'completed';
 					} else {
 						status = 'active';
 					}
-					previousCompleted = true; // Always allow next lessons for whitelisted users
+					previousCompleted = true; // Always allow next lessons for whitelisted/subscribed users
 				} else if (!isFirstLesson && !isSubscribed) {
 					// All lessons except the first one require subscription
 					status = 'locked';


### PR DESCRIPTION
## Summary
- Subscribers can now access all structured lessons in any order, instead of having to complete each lesson before the next unlocks
- The lesson-path status logic in `src/routes/lessons/structured/[dialect]/+page.svelte` previously only fully unlocked lessons for whitelisted users; subscribers now get the same treatment
- Free users are unaffected: the first lesson stays free and everything past it remains paywalled

## Notes
- `/api/lessons/[id]` has no server-side ordering check, so this client-side change is the whole fix
- Other lesson routes (`/lessons`, `/lessons/custom`, structured overview) have no sequential gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)