### PR TITLE
feat: persist generated practice content across navigation

### DIFF
--- a/src/lib/store/generated-content.svelte.ts
+++ b/src/lib/store/generated-content.svelte.ts
@@ -1,0 +1,46 @@
+// Generated practice content, kept in module-level state so it survives
+// client-side navigation. Only written in the browser; resets on full reload.
+import type { sentenceObjectItem } from '$lib/types/index';
+import type { ConjugationExerciseSchema } from '$lib/utils/gemini-schemas';
+
+export interface SentencePracticeSession {
+	sentences: sentenceObjectItem[];
+	index: number;
+	dialect: string;
+}
+
+export const sentencePractice = $state<SentencePracticeSession>({
+	sentences: [],
+	index: 0,
+	dialect: ''
+});
+
+export const speakPractice = $state<SentencePracticeSession>({
+	sentences: [],
+	index: 0,
+	dialect: ''
+});
+
+export const conjugationPractice = $state({
+	verb: '',
+	dialect: '',
+	exercise: null as ConjugationExerciseSchema | null
+});
+
+// Snapshot of an in-progress vocabulary game, keyed by the play page's URL
+// search params so a different game setup starts fresh.
+export interface GameSnapshot {
+	paramsKey: string;
+	questions: unknown[];
+	currentIndex: number;
+	score: number;
+	wordsToReview: unknown[];
+	sentencesToReview: unknown[];
+	questionOrder: string[];
+	gameProgressId: string | null;
+	turnsPlayed: number;
+}
+
+export const gameSession = $state({
+	snapshot: null as GameSnapshot | null
+});

--- a/src/routes/conjugations/+page.svelte
+++ b/src/routes/conjugations/+page.svelte
@@ -5,7 +5,7 @@
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
 	import { type Dialect } from '$lib/types/index';
-	import type { ConjugationExerciseSchema } from '$lib/utils/gemini-schemas';
+	import { conjugationPractice as session } from '$lib/store/generated-content.svelte';
 
 	let { data } = $props();
 
@@ -18,9 +18,9 @@
 
 	const exampleVerbs = ['to write', 'to eat', 'to go', 'to drink', 'to study', 'to speak'];
 
-	let selectedDialect = $state(getDefaultDialect(data.user));
-	let verb = $state('');
-	let conjugationData = $state<ConjugationExerciseSchema | null>(null);
+	// Generated exercise lives in global state so it survives navigating away
+	let selectedDialect = $state(session.dialect || getDefaultDialect(data.user));
+	let verb = $state(session.verb);
 
 	let isLoading = $state(false);
 	let isError = $state(false);
@@ -36,7 +36,7 @@
 		isLoading = true;
 		isError = false;
 		errorMessage = '';
-		conjugationData = null;
+		session.exercise = null;
 
 		try {
 			const res = await fetch('/api/generate-conjugations', {
@@ -50,7 +50,9 @@
 				throw new Error(body.message || `Server error: ${res.status}`);
 			}
 
-			conjugationData = (await res.json()) as ConjugationExerciseSchema;
+			session.exercise = await res.json();
+			session.verb = verb.trim();
+			session.dialect = selectedDialect;
 		} catch (error) {
 			console.error('Error generating conjugations:', error);
 			isError = true;
@@ -72,7 +74,8 @@
 	}
 
 	function onNewVerb() {
-		conjugationData = null;
+		session.exercise = null;
+		session.verb = '';
 		verb = '';
 		isError = false;
 		errorMessage = '';
@@ -103,9 +106,9 @@
 			</div>
 		</div>
 	</div>
-{:else if conjugationData}
+{:else if session.exercise}
 	<div class="px-4 sm:px-8 py-8">
-		<ConjugationPractice data={conjugationData} dialect={selectedDialect as Dialect} {onNewVerb} {onAdvance} />
+		<ConjugationPractice data={session.exercise} dialect={selectedDialect as Dialect} {onNewVerb} {onAdvance} />
 	</div>
 {:else}
 	<!-- Generation form -->

--- a/src/routes/learn/game/play/+page.svelte
+++ b/src/routes/learn/game/play/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
+  import { gameSession } from '$lib/store/generated-content.svelte';
   import { Howl } from 'howler';
   import levenshtein from 'fast-levenshtein';
   import AudioButton from '$lib/components/AudioButton.svelte';
@@ -91,12 +92,53 @@
   let currentQuestion = $derived(questions[currentIndex]);
   let progress = $derived(questions.length > 0 ? ((currentIndex + 1) / questions.length) * 100 : 0);
 
+  // URL search params identify this game setup; captured at mount because the
+  // URL has already changed by the time onDestroy runs during navigation
+  let sessionParamsKey = '';
+
   onMount(async () => {
     await initializeGame();
   });
 
+  // Keep the in-progress game in global state so navigating away doesn't
+  // lose generated questions; cleared when the game is completed
+  onDestroy(() => {
+    if (!gameComplete && questions.length > 0 && sessionParamsKey) {
+      gameSession.snapshot = {
+        paramsKey: sessionParamsKey,
+        questions: $state.snapshot(questions),
+        currentIndex,
+        score,
+        wordsToReview: $state.snapshot(wordsToReview),
+        sentencesToReview: $state.snapshot(sentencesToReview),
+        questionOrder: $state.snapshot(questionOrder),
+        gameProgressId,
+        turnsPlayed
+      };
+    } else if (gameComplete) {
+      gameSession.snapshot = null;
+    }
+  });
+
   async function initializeGame() {
     isLoading = true;
+    sessionParamsKey = window.location.search;
+
+    // Restore an in-memory session from earlier this visit (after navigating away)
+    const saved = gameSession.snapshot;
+    if (saved && saved.paramsKey === sessionParamsKey) {
+      sessionStorage.removeItem('resumeGame');
+      questions = saved.questions as GameQuestion[];
+      currentIndex = saved.currentIndex;
+      score = saved.score;
+      wordsToReview = saved.wordsToReview as Word[];
+      sentencesToReview = saved.sentencesToReview as Sentence[];
+      questionOrder = saved.questionOrder;
+      gameProgressId = saved.gameProgressId;
+      turnsPlayed = saved.turnsPlayed;
+      isLoading = false;
+      return;
+    }
 
     // Check if we're resuming a game (from server-side data or sessionStorage)
     const serverResumeData = data.resumeData;

--- a/src/routes/sentences/+page.svelte
+++ b/src/routes/sentences/+page.svelte
@@ -15,6 +15,7 @@
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
 	import { fetchUserReviewWords } from '$lib/helpers/fetch-review-words';
+	import { sentencePractice as session } from '$lib/store/generated-content.svelte';
 
 	let { data } = $props();
 
@@ -26,14 +27,13 @@
 		currentDialect.set('');
 	});
 
-	let index = $state((() => {
-		if (typeof window !== 'undefined') {
-			const params = new URLSearchParams(window.location.search);
-			const urlIndex = parseInt(params.get('sentence') ?? '0') || 0;
-			return urlIndex ? urlIndex - 1 : 0;
-		}
-		return 0;
-	})());
+	// Sentences live in global state so they survive navigating away; only
+	// read the index from the URL when there is no session to come back to.
+	if (typeof window !== 'undefined' && session.sentences.length === 0) {
+		const params = new URLSearchParams(window.location.search);
+		const urlIndex = parseInt(params.get('sentence') ?? '0') || 0;
+		session.index = urlIndex ? urlIndex - 1 : 0;
+	}
 
 	// Function to filter out incomplete sentences
 	function filterValidSentences(sentences: any[]): sentenceObjectItem[] {
@@ -48,13 +48,12 @@
 		);
 	}
 
-	let selectedDialect = $state(getDefaultDialect(data.user));
-	let sentences = $state<sentenceObjectItem[]>([]);
+	let selectedDialect = $state(session.dialect || getDefaultDialect(data.user));
 
-	let sentence = $derived(sentences[index]);
+	let sentence = $derived(session.sentences[session.index]);
 	$effect(() => {
-		if (sentences.length > 0) {
-			index = Math.min(index, sentences.length - 1);
+		if (session.sentences.length > 0) {
+			session.index = Math.min(session.index, session.sentences.length - 1);
 		}
 	});
 
@@ -259,8 +258,10 @@
 				throw new Error('No valid sentences were generated. Please try again.');
 			}
 			
-			const updatedSentences = [...sentences, ...newSentences];
-			sentences = updatedSentences;
+			// Write to global state so the result survives navigating away,
+			// even if generation finishes after this page is destroyed
+			session.sentences = [...session.sentences, ...newSentences];
+			session.dialect = selectedDialect;
 
 			// Show success toast
 			showSentenceSuccessToast(toastId, newSentences.length, selectedDialect);
@@ -290,21 +291,21 @@
 	}
 
 	function next() {
-		if (index === sentences.length - 1) {
+		if (session.index === session.sentences.length - 1) {
 			return;
 		}
 
 		updateSentencesViewed();
-		index = index + 1;
-		updateUrl('sentence', (index+1).toString());
+		session.index = session.index + 1;
+		updateUrl('sentence', (session.index+1).toString());
 	}
 
 	function previous() {
-		if (index === 0) {
+		if (session.index === 0) {
 			return;
 		}
-		index = index - 1;
-		updateUrl('sentence', (index+1).toString());
+		session.index = session.index - 1;
+		updateUrl('sentence', (session.index+1).toString());
 	}
 
 	function setMode(event: any) {
@@ -319,28 +320,28 @@
 
 	function setDialect(event: any) {
 		selectedDialect = event.target.value;
-		sentences = [];
-		index = 0;
+		session.sentences = [];
+		session.index = 0;
 		updateUrl('sentence', '0');
 	}
 
 	function generateSentences(event: any) {
 		event.preventDefault();
-		const copy = [...sentences];
+		const copy = [...session.sentences];
 		generateSentence(option, copy);
 	}
 
 	function loadMoreSentences() {
-		generateSentence(option, sentences);
+		generateSentence(option, [...session.sentences]);
 	}
 
 	function resetSentences() {
-		sentences = [];
-		index = 0;
+		session.sentences = [];
+		session.index = 0;
 		updateUrl('sentence', '0');
 	}
 
-	let isLastSentence = $derived(index === sentences.length - 1);
+	let isLastSentence = $derived(session.index === session.sentences.length - 1);
 	let hasReachedLimit = $derived(!data.isSubscribed && sentencesViewed >= 5);
 
 	const dialectOptions = [
@@ -401,7 +402,7 @@
 	</div>
 {/if}
 
-{#if !isLoading && sentences.length === 0 && !hasReachedLimit}
+{#if !isLoading && session.sentences.length === 0 && !hasReachedLimit}
 	<!-- Generation Form -->
 	<header class="py-5 bg-tile-200 border-b border-tile-500 px-6 sm:px-12">
 		<div class=" text-left">
@@ -748,26 +749,26 @@
 			</div>
 		</div>
 	</div>
-{:else if sentences.length > 0 && index < sentences.length && !hasReachedLimit}
+{:else if session.sentences.length > 0 && session.index < session.sentences.length && !hasReachedLimit}
 	<div class="min-h-screen flex flex-col">
 		<header class="sticky top-0 z-10 border-b border-tile-600 bg-tile-400/95 backdrop-blur-sm shadow-md">
 			<div class="max-w-7xl mx-auto px-4 sm:px-8 py-4">
 				<div class="flex w-full items-center justify-between">
 					<div class="w-24">
-						{#if index > 0}
+						{#if session.index > 0}
 							<Button onClick={previous} type="button" className="!py-1.5 !px-3 text-sm shadow-sm">Previous</Button>
 						{/if}
 					</div>
 					<div class="text-center">
 						<h1 class="text-lg font-bold text-text-300 flex items-center gap-2 justify-center">
-							<span>Sentence {index + 1}</span>
+							<span>Sentence {session.index + 1}</span>
 							<span class="text-text-200 font-normal">of</span>
-							<span>{sentences.length}</span>
+							<span>{session.sentences.length}</span>
 						</h1>
 						<p class="text-xs text-text-200 font-medium uppercase tracking-wider mt-0.5">{dialectOptions.find(d => d.value === selectedDialect)?.label}</p>
 					</div>
 					<div class="w-24 flex justify-end gap-2">
-						{#if index < sentences.length - 1}
+						{#if session.index < session.sentences.length - 1}
 							<Button onClick={next} type="button" className="!py-1.5 !px-3 text-sm shadow-sm">Next</Button>
 						{/if}
 						{#if isLastSentence && !isLoading}
@@ -807,10 +808,10 @@
 
 			{#if mode === 'quiz'}
 				<section class="px-4 sm:px-8 max-w-7xl mx-auto py-8">
-					<SentenceQuiz 
-					{sentences}
-					 {index} 
-					 {resetSentences} 
+					<SentenceQuiz
+					sentences={session.sentences}
+					 index={session.index}
+					 {resetSentences}
 					 {next}
 					 />
 				</section>

--- a/src/routes/speak/+page.svelte
+++ b/src/routes/speak/+page.svelte
@@ -14,6 +14,7 @@
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
 	import { fetchUserReviewWords } from '$lib/helpers/fetch-review-words';
+	import { speakPractice as session } from '$lib/store/generated-content.svelte';
 
 	let { data } = $props();
 
@@ -25,14 +26,13 @@
 		currentDialect.set('');
 	});
 
-	let index = $state((() => {
-		if (typeof window !== 'undefined') {
-			const params = new URLSearchParams(window.location.search);
-			const urlIndex = parseInt(params.get('speak_sentence') ?? '0') || 0;
-			return urlIndex ? urlIndex - 1 : 0;
-		}
-		return 0;
-	})());
+	// Sentences live in global state so they survive navigating away; only
+	// read the index from the URL when there is no session to come back to.
+	if (typeof window !== 'undefined' && session.sentences.length === 0) {
+		const params = new URLSearchParams(window.location.search);
+		const urlIndex = parseInt(params.get('speak_sentence') ?? '0') || 0;
+		session.index = urlIndex ? urlIndex - 1 : 0;
+	}
 
 	// Function to filter out incomplete sentences
 	function filterValidSentences(sentences: any[]): sentenceObjectItem[] {
@@ -47,13 +47,12 @@
 		);
 	}
 
-	let selectedDialect = $state(getDefaultDialect(data.user));
-	let sentences = $state<sentenceObjectItem[]>([]);
+	let selectedDialect = $state(session.dialect || getDefaultDialect(data.user));
 
-	let sentence = $derived(sentences[index]);
+	let sentence = $derived(session.sentences[session.index]);
 	$effect(() => {
-		if (sentences.length > 0) {
-			index = Math.min(index, sentences.length - 1);
+		if (session.sentences.length > 0) {
+			session.index = Math.min(session.index, session.sentences.length - 1);
 		}
 	});
 
@@ -242,8 +241,10 @@
 				throw new Error('No valid sentences were generated. Please try again.');
 			}
 			
-			const updatedSentences = [...sentences, ...newSentences];
-			sentences = updatedSentences;
+			// Write to global state so the result survives navigating away,
+			// even if generation finishes after this page is destroyed
+			session.sentences = [...session.sentences, ...newSentences];
+			session.dialect = selectedDialect;
 
 			showSpeakSentenceSuccessToast(toastId, newSentences.length, selectedDialect);
 			
@@ -271,21 +272,21 @@
 	}
 
 	function next() {
-		if (index === sentences.length - 1) {
+		if (session.index === session.sentences.length - 1) {
 			return;
 		}
 
 		updateSentencesViewed();
-		index = index + 1;
-		updateUrl('speak_sentence', (index+1).toString());
+		session.index = session.index + 1;
+		updateUrl('speak_sentence', (session.index+1).toString());
 	}
 
 	function previous() {
-		if (index === 0) {
+		if (session.index === 0) {
 			return;
 		}
-		index = index - 1;
-		updateUrl('speak_sentence', (index+1).toString());
+		session.index = session.index - 1;
+		updateUrl('speak_sentence', (session.index+1).toString());
 	}
 
 	function setOption(event: any) {
@@ -294,28 +295,28 @@
 
 	function setDialect(event: any) {
 		selectedDialect = event.target.value;
-		sentences = [];
-		index = 0;
+		session.sentences = [];
+		session.index = 0;
 		updateUrl('speak_sentence', '0');
 	}
 
 	function generateSentences(event: any) {
 		event.preventDefault();
-		const copy = [...sentences];
+		const copy = [...session.sentences];
 		generateSentence(option, copy);
 	}
 
 	function loadMoreSentences() {
-		generateSentence(option, sentences);
+		generateSentence(option, [...session.sentences]);
 	}
 
 	function resetSentences() {
-		sentences = [];
-		index = 0;
+		session.sentences = [];
+		session.index = 0;
 		updateUrl('speak_sentence', '0');
 	}
 
-	let isLastSentence = $derived(index === sentences.length - 1);
+	let isLastSentence = $derived(session.index === session.sentences.length - 1);
 	let hasReachedLimit = $derived(!data.isSubscribed && sentencesViewed >= 5);
 
 	const dialectOptions = [
@@ -401,7 +402,7 @@
 			</div>
 		</div>
 
-	{:else if sentences.length === 0 && !hasReachedLimit}
+	{:else if session.sentences.length === 0 && !hasReachedLimit}
 		<!-- Generation Form -->
 		<header class="bg-tile-200 border-b border-tile-500">
 			<div class="max-w-4xl mx-auto px-4 sm:px-8 py-6 sm:py-8">
@@ -727,13 +728,13 @@
 			</div>
 		</section>
 
-	{:else if sentences.length > 0 && index < sentences.length && !hasReachedLimit}
+	{:else if session.sentences.length > 0 && session.index < session.sentences.length && !hasReachedLimit}
 		<!-- Practice Mode Header -->
 		<header class="py-3 bg-tile-400 border-b border-tile-500 sticky top-0 z-20 shadow-sm">
 			<div class="max-w-7xl mx-auto px-4 sm:px-8">
 				<div class="flex items-center justify-between">
 					<div class="w-28">
-						{#if index > 0}
+						{#if session.index > 0}
 							<button 
 								onclick={previous} 
 								class="flex items-center gap-1 px-4 py-2 bg-tile-500 text-text-300 font-semibold rounded-lg hover:bg-tile-600 transition-colors border border-tile-600"
@@ -749,7 +750,7 @@
 					<div class="flex flex-col items-center">
 						<div class="flex items-center gap-3">
 							<span class="px-3 py-1 bg-tile-500 rounded-full text-sm font-bold text-text-300">
-								{index + 1} / {sentences.length}
+								{session.index + 1} / {session.sentences.length}
 							</span>
 						</div>
 						<span class="text-xs text-text-200 mt-1">
@@ -758,7 +759,7 @@
 					</div>
 					
 					<div class="w-28 flex justify-end gap-2">
-						{#if index < sentences.length - 1}
+						{#if session.index < session.sentences.length - 1}
 							<button 
 								onclick={next} 
 								class="flex items-center gap-1 px-4 py-2 bg-tile-500 text-text-300 font-semibold rounded-lg hover:bg-tile-600 transition-colors border border-tile-600"


### PR DESCRIPTION
## Summary
- Adds a shared runes-based state module (`src/lib/store/generated-content.svelte.ts`) that holds generated practice content so client-side navigation no longer discards it (state still resets on a full page reload)
- **/sentences** and **/speak**: the generated sentence list, current index, and dialect are backed by the store; generation writes directly into it, so sentences that finish generating *after* you leave the page are there when you come back
- **/conjugations**: the generated conjugation exercise, verb, and dialect persist the same way; "New verb" clears them
- **/learn/game/play**: generated questions plus progress (index, score, review items, question order, progress ID, turns played) are snapshotted on navigation away and restored when returning to the same game URL; completing the game clears the snapshot

## Notes
- The existing DB-backed resume flow for category games is untouched; the snapshot check runs first and defers to it when keys don't match
- Limitation: leaving the game page mid-generation still loses that in-flight result (unlike the sentence pages)
- No new svelte-check errors in the touched files; autofixer findings there predate this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)