### PR TITLE
feat(analytics): PostHog event tracking across learning routes

### DIFF
--- a/.claude/skills/integration-sveltekit/SKILL.md
+++ b/.claude/skills/integration-sveltekit/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: integration-sveltekit
+description: PostHog integration for SvelteKit applications
+metadata:
+  author: PostHog
+  version: 1.21.1
+---
+
+# PostHog integration for SvelteKit
+
+This skill helps you add PostHog analytics to SvelteKit applications.
+
+## Workflow
+
+Follow these steps in order to complete the integration:
+
+1. `basic-integration-1.0-begin.md` - PostHog Setup - Begin ← **Start here**
+2. `basic-integration-1.1-edit.md` - PostHog Setup - Edit
+3. `basic-integration-1.2-revise.md` - PostHog Setup - Revise
+4. `basic-integration-1.3-conclude.md` - PostHog Setup - Conclusion
+
+## Reference files
+
+- `references/EXAMPLE.md` - SvelteKit example project code
+- `references/svelte.md` - Svelte - docs
+- `references/identify-users.md` - Identify users - docs
+- `references/basic-integration-1.0-begin.md` - PostHog setup - begin
+- `references/basic-integration-1.1-edit.md` - PostHog setup - edit
+- `references/basic-integration-1.2-revise.md` - PostHog setup - revise
+- `references/basic-integration-1.3-conclude.md` - PostHog setup - conclusion
+
+The example project shows the target implementation pattern. Consult the documentation for API details.
+
+## Key principles
+
+- **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
+- **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
+- **Match the example**: Your implementation should follow the example project's patterns as closely as possible.
+
+## Framework guidelines
+
+- Set paths.relative to false in svelte.config.js — this is required for PostHog session replay to work correctly with SSR and is easy to miss
+- Use the Svelte MCP server tools to check Svelte documentation (list-sections, get-documentation) and validate components (svelte-autofixer) — always run svelte-autofixer on new or modified .svelte files before finishing
+- When a reverse proxy is configured, both /static/* AND /array/* must route to the assets origin (us-assets.i.posthog.com or eu-assets.i.posthog.com).
+
+## Identifying users
+
+Identify users during login and signup events. Refer to the example code and documentation for the correct identify pattern for this framework. If both frontend and backend code exist, pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to maintain correlation.
+
+## Error tracking
+
+Add PostHog error tracking to relevant files, particularly around critical user flows and API boundaries.

--- a/.claude/skills/integration-sveltekit/references/EXAMPLE.md
+++ b/.claude/skills/integration-sveltekit/references/EXAMPLE.md
@@ -1,0 +1,851 @@
+# PostHog SvelteKit Example Project
+
+Repository: https://github.com/PostHog/context-mill
+Path: basics/sveltekit
+
+---
+
+## README.md
+
+# SvelteKit PostHog example
+
+This example demonstrates how to integrate PostHog with a SvelteKit application, including:
+
+- Client-side PostHog initialization using SvelteKit hooks
+- Server-side PostHog tracking with the Node.js SDK
+- Reverse proxy to avoid ad blockers
+- User identification and event tracking
+- Error tracking with `captureException`
+- Session replay configuration
+
+## Getting started
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Configure environment variables
+
+Copy the example environment file and add your PostHog credentials:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your PostHog project token:
+
+```
+PUBLIC_POSTHOG_PROJECT_TOKEN=your_posthog_project_token_here
+PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+```
+
+You can find your project token in your [PostHog project settings](https://app.posthog.com/project/settings).
+
+### 3. Run the development server
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173) to view the app.
+
+## Project structure
+
+```
+src/
+├── lib/
+│   ├── auth.svelte.ts              # Auth context with Svelte 5 runes
+│   ├── components/
+│   │   └── Header.svelte           # Navigation component
+│   └── server/
+│       └── posthog.ts              # Server-side PostHog singleton
+├── routes/
+│   ├── +layout.svelte              # Root layout with auth provider
+│   ├── +page.svelte                # Home/login page
+│   ├── burrito/
+│   │   └── +page.svelte            # Event tracking demo
+│   ├── profile/
+│   │   └── +page.svelte            # Error tracking demo
+│   └── api/
+│       └── auth/
+│           └── login/
+│               └── +server.ts      # Login API with server-side tracking
+├── hooks.client.ts                 # Client-side PostHog init + error handling
+├── hooks.server.ts                 # Server hooks with reverse proxy
+├── app.css                         # Global styles
+└── app.html                        # HTML template
+```
+
+## Key integration points
+
+### Client-side initialization (`src/hooks.client.ts`)
+
+PostHog is initialized in the SvelteKit client hooks `init` function, which runs once when the app starts:
+
+```typescript
+import posthog from 'posthog-js';
+
+export async function init() {
+  posthog.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
+    defaults: '2026-01-30',
+    capture_exceptions: true
+  });
+}
+```
+
+### Server-side tracking (`src/lib/server/posthog.ts`)
+
+A singleton pattern ensures one PostHog client instance for server-side tracking:
+
+```typescript
+import { PostHog } from 'posthog-node';
+
+let posthogClient: PostHog | null = null;
+
+export function getPostHogClient() {
+  if (!posthogClient) {
+    posthogClient = new PostHog(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+      host: PUBLIC_POSTHOG_HOST,
+      flushAt: 1,
+      flushInterval: 0
+    });
+  }
+  return posthogClient;
+}
+```
+
+### Reverse proxy (`src/hooks.server.ts`)
+
+The server hooks handle proxies requests through `/ingest` to avoid ad blockers:
+
+```typescript
+export const handle: Handle = async ({ event, resolve }) => {
+  if (event.url.pathname.startsWith('/ingest')) {
+    const pathname = event.url.pathname.replace('/ingest', '');
+    const host = pathname.startsWith('/static')
+      ? 'https://us-assets.i.posthog.com'
+      : 'https://us.i.posthog.com';
+    // Proxy to PostHog...
+  }
+  return resolve(event);
+};
+```
+
+### User identification
+
+When a user logs in, they are identified in PostHog:
+
+```typescript
+import posthog from 'posthog-js';
+
+// On login
+posthog.identify(userId, { username });
+posthog.capture('user_logged_in', { username });
+
+// On logout
+posthog.capture('user_logged_out');
+posthog.reset();
+```
+
+### Error tracking
+
+Errors are automatically captured via the `handleError` hook:
+
+```typescript
+export const handleError: HandleClientError = async ({ error }) => {
+  posthog.captureException(error);
+  return { message: 'An error occurred' };
+};
+```
+
+You can also manually capture errors:
+
+```typescript
+try {
+  // Some operation
+} catch (err) {
+  posthog.captureException(err);
+}
+```
+
+### Session replay configuration
+
+For session replay to work correctly, add this to `svelte.config.js`:
+
+```javascript
+export default {
+  kit: {
+    paths: {
+      relative: false
+    }
+  }
+};
+```
+
+## Features demonstrated
+
+1. **Login page** (`/`) - User authentication with PostHog identification
+2. **Burrito page** (`/burrito`) - Custom event tracking with properties
+3. **Profile page** (`/profile`) - Error tracking demonstration
+
+## Learn more
+
+- [PostHog Svelte documentation](https://posthog.com/docs/libraries/svelte)
+- [PostHog SvelteKit proxy setup](https://posthog.com/docs/advanced/proxy/sveltekit)
+- [SvelteKit documentation](https://svelte.dev/docs/kit)
+
+---
+
+## .env.example
+
+```example
+# PostHog configuration
+# Get your PostHog project token from: https://app.posthog.com/project/settings
+PUBLIC_POSTHOG_PROJECT_TOKEN=your_posthog_project_token_here
+PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+```
+
+---
+
+## .npmrc
+
+```
+engine-strict=true
+min-release-age=7
+
+```
+
+---
+
+## src/app.d.ts
+
+```ts
+// See https://svelte.dev/docs/kit/types#app.d.ts
+// for information about these interfaces
+declare global {
+	namespace App {
+		// interface Error {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface PageState {}
+		// interface Platform {}
+	}
+}
+
+export {};
+
+```
+
+---
+
+## src/app.html
+
+```html
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>
+
+```
+
+---
+
+## src/hooks.client.ts
+
+```ts
+import posthog from 'posthog-js';
+import { PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public';
+import type { HandleClientError } from '@sveltejs/kit';
+
+// Initialize PostHog when the app starts in the browser
+export async function init() {
+	posthog.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+		api_host: '/ingest',
+		ui_host: 'https://us.posthog.com',
+  defaults: '2026-01-30',
+		capture_exceptions: true
+	});
+}
+
+// Capture client-side errors with PostHog
+export const handleError: HandleClientError = async ({ error, status, message }) => {
+	posthog.captureException(error);
+
+	return {
+		message,
+		status
+	};
+};
+
+```
+
+---
+
+## src/hooks.server.ts
+
+```ts
+import type { Handle, HandleServerError } from '@sveltejs/kit';
+import { getPostHogClient } from '$lib/server/posthog';
+
+// Handle requests - includes reverse proxy for PostHog
+export const handle: Handle = async ({ event, resolve }) => {
+	const { pathname } = event.url;
+
+	// Reverse proxy for PostHog - route /ingest requests to PostHog servers
+	if (pathname.startsWith('/ingest')) {
+		const useAssetHost = pathname.startsWith('/ingest/static/') || pathname.startsWith('/ingest/array/')
+		const hostname = useAssetHost ? 'us-assets.i.posthog.com' : 'us.i.posthog.com';
+
+		const url = new URL(event.request.url);
+		url.protocol = 'https:';
+		url.hostname = hostname;
+		url.port = '443';
+		url.pathname = pathname.replace(/^\/ingest/, '');
+
+		const headers = new Headers(event.request.headers);
+		headers.set('host', hostname);
+		headers.set('accept-encoding', '');
+
+		const clientIp = event.request.headers.get('x-forwarded-for') || event.getClientAddress();
+		if (clientIp) {
+			headers.set('x-forwarded-for', clientIp);
+		}
+
+		const response = await fetch(url.toString(), {
+			method: event.request.method,
+			headers,
+			body: event.request.body,
+			// @ts-expect-error - duplex is required for streaming request bodies
+			duplex: 'half'
+		});
+
+		return response;
+	}
+
+	return resolve(event);
+};
+
+// Capture server-side errors with PostHog
+export const handleError: HandleServerError = async ({ error, status, message }) => {
+	const posthog = getPostHogClient();
+
+	posthog.capture({
+		distinctId: 'server',
+		event: 'server_error',
+		properties: {
+			error: error instanceof Error ? error.message : String(error),
+			status,
+			message
+		}
+	});
+
+	return {
+		message,
+		status
+	};
+};
+
+```
+
+---
+
+## src/lib/auth.svelte.ts
+
+```ts
+import { getContext, setContext } from 'svelte';
+import posthog from 'posthog-js';
+import { browser } from '$app/environment';
+
+export interface User {
+	username: string;
+	burritoConsiderations: number;
+}
+
+const AUTH_KEY = Symbol('auth');
+
+// Class-based auth state using Svelte 5 $state in class fields
+// This is the recommended pattern for encapsulating reactive state + behavior
+export class AuthState {
+	user = $state<User | null>(null);
+
+	constructor() {
+		// Restore user from localStorage on creation (browser only)
+		if (browser) {
+			const storedUsername = localStorage.getItem('currentUser');
+			if (storedUsername) {
+				this.user = { username: storedUsername, burritoConsiderations: 0 };
+			}
+		}
+	}
+
+	login = async (username: string, password: string): Promise<boolean> => {
+		try {
+			const response = await fetch('/api/auth/login', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ username, password })
+			});
+
+			if (response.ok) {
+				const { user: userData } = await response.json();
+				this.user = userData as User;
+
+				if (browser) {
+					localStorage.setItem('currentUser', username);
+					posthog.identify(username, { username });
+					posthog.capture('user_logged_in', { username });
+				}
+
+				return true;
+			}
+			return false;
+		} catch (error) {
+			console.error('Login error:', error);
+			return false;
+		}
+	};
+
+	logout = (): void => {
+		if (browser) {
+			posthog.capture('user_logged_out');
+			posthog.reset();
+			localStorage.removeItem('currentUser');
+		}
+		this.user = null;
+	};
+
+	incrementBurritoConsiderations = (): void => {
+		if (this.user) {
+			this.user = {
+				...this.user,
+				burritoConsiderations: this.user.burritoConsiderations + 1
+			};
+		}
+	};
+}
+
+export function setAuthContext(auth: AuthState) {
+	setContext(AUTH_KEY, auth);
+}
+
+export function getAuthContext(): AuthState {
+	return getContext<AuthState>(AUTH_KEY);
+}
+
+```
+
+---
+
+## src/lib/components/Header.svelte
+
+```svelte
+<script lang="ts">
+	import { getAuthContext } from '$lib/auth.svelte';
+
+	const auth = getAuthContext();
+</script>
+
+<header class="header">
+	<div class="header-container">
+		<nav>
+			<a href="/">Home</a>
+			{#if auth.user}
+				<a href="/burrito">Burrito</a>
+				<a href="/profile">Profile</a>
+			{/if}
+		</nav>
+		<div class="user-section">
+			{#if auth.user}
+				<span>Welcome, {auth.user.username}</span>
+				<button class="btn-logout" onclick={() => auth.logout()}>Logout</button>
+			{/if}
+		</div>
+	</div>
+</header>
+
+```
+
+---
+
+## src/lib/index.ts
+
+```ts
+// place files you want to import through the `$lib` alias in this folder.
+
+```
+
+---
+
+## src/lib/server/posthog.ts
+
+```ts
+import { PostHog } from 'posthog-node';
+import { PUBLIC_POSTHOG_PROJECT_TOKEN, PUBLIC_POSTHOG_HOST } from '$env/static/public';
+
+let posthogClient: PostHog | null = null;
+
+export function getPostHogClient() {
+	if (!posthogClient) {
+		posthogClient = new PostHog(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+			host: PUBLIC_POSTHOG_HOST,
+			flushAt: 1,
+			flushInterval: 0
+		});
+	}
+	return posthogClient;
+}
+
+export async function shutdownPostHog() {
+	if (posthogClient) {
+		await posthogClient.shutdown();
+	}
+}
+
+```
+
+---
+
+## src/routes/+layout.svelte
+
+```svelte
+<script lang="ts">
+	import { AuthState, setAuthContext } from '$lib/auth.svelte';
+	import Header from '$lib/components/Header.svelte';
+	import '../app.css';
+
+	let { children } = $props();
+
+	// Create and provide auth context
+	const auth = new AuthState();
+	setAuthContext(auth);
+</script>
+
+<svelte:head>
+	<title>Burrito consideration app</title>
+	<meta name="description" content="Consider the potential of burritos with PostHog analytics" />
+</svelte:head>
+
+<Header />
+<main>
+	{@render children()}
+</main>
+
+```
+
+---
+
+## src/routes/+page.svelte
+
+```svelte
+<script lang="ts">
+	import { getAuthContext } from '$lib/auth.svelte';
+
+	const auth = getAuthContext();
+
+	let username = $state('');
+	let password = $state('');
+	let error = $state('');
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+
+		try {
+			const success = await auth.login(username, password);
+			if (success) {
+				username = '';
+				password = '';
+			} else {
+				error = 'Please provide both username and password';
+			}
+		} catch (err) {
+			console.error('Login failed:', err);
+			error = 'An error occurred during login';
+		}
+	}
+</script>
+
+<div class="container">
+	{#if auth.user}
+		<h1>Welcome back, {auth.user.username}!</h1>
+		<p>You are now logged in. Check out the navigation to explore features.</p>
+		<ul>
+			<li><a href="/burrito">Consider a burrito</a></li>
+			<li><a href="/profile">View your profile</a></li>
+		</ul>
+	{:else}
+		<h1>Welcome to Burrito consideration app</h1>
+		<p>Sign in to start considering burritos.</p>
+
+		<form class="form" onsubmit={handleSubmit}>
+			<div class="form-group">
+				<label for="username">Username:</label>
+				<input type="text" id="username" bind:value={username} required />
+			</div>
+
+			<div class="form-group">
+				<label for="password">Password:</label>
+				<input type="password" id="password" bind:value={password} required />
+			</div>
+
+			{#if error}
+				<p class="error">{error}</p>
+			{/if}
+
+			<button type="submit" class="btn-primary">Sign In</button>
+		</form>
+
+		<p class="note">
+			Enter any username and password to sign in. This is a demo app.
+		</p>
+	{/if}
+</div>
+
+```
+
+---
+
+## src/routes/api/auth/login/+server.ts
+
+```ts
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getPostHogClient } from '$lib/server/posthog';
+
+const users = new Map<string, { username: string; burritoConsiderations: number }>();
+
+export const POST: RequestHandler = async ({ request }) => {
+	const { username, password } = await request.json();
+
+	if (!username || !password) {
+		return json({ error: 'Username and password required' }, { status: 400 });
+	}
+
+	let user = users.get(username);
+	const isNewUser = !user;
+
+	if (!user) {
+		user = { username, burritoConsiderations: 0 };
+		users.set(username, user);
+	}
+
+	// Capture server-side login event with user context
+	const posthog = getPostHogClient();
+	posthog.withContext(
+		{
+			distinctId: username,
+			personProperties: {
+				username,
+				createdAt: isNewUser ? new Date().toISOString() : undefined
+			}
+		},
+		() => {
+			posthog.capture({
+				event: 'server_login',
+				properties: {
+					isNewUser,
+					source: 'api'
+				}
+			});
+		}
+	);
+
+	// Flush events to ensure they're sent
+	await posthog.flush();
+
+	return json({ success: true, user });
+};
+
+```
+
+---
+
+## src/routes/burrito/+page.svelte
+
+```svelte
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { browser } from '$app/environment';
+	import posthog from 'posthog-js';
+	import { getAuthContext } from '$lib/auth.svelte';
+
+	const auth = getAuthContext();
+
+	let hasConsidered = $state(false);
+
+	// Redirect to home if not logged in
+	$effect(() => {
+		if (browser && !auth.user) {
+			goto('/');
+		}
+	});
+
+	function handleConsideration() {
+		if (!auth.user) return;
+
+		auth.incrementBurritoConsiderations();
+		hasConsidered = true;
+		setTimeout(() => (hasConsidered = false), 2000);
+
+		// Capture burrito consideration event with PostHog
+		posthog.capture('burrito_considered', {
+			total_considerations: auth.user.burritoConsiderations,
+			username: auth.user.username
+		});
+	}
+</script>
+
+<div class="container">
+	{#if auth.user}
+		<h1>Burrito consideration zone</h1>
+		<p>This is where you consider the infinite potential of burritos.</p>
+		<p>Current considerations: <strong>{auth.user.burritoConsiderations}</strong></p>
+
+		<button class="btn-burrito" onclick={handleConsideration}>
+			I have considered the burrito potential
+		</button>
+
+		{#if hasConsidered}
+			<p class="success">
+				Thank you for your consideration! Count: {auth.user.burritoConsiderations}
+			</p>
+		{/if}
+
+		<div class="note">
+			<p>Each consideration is tracked as a PostHog event with custom properties.</p>
+		</div>
+	{:else}
+		<p>Please log in to consider burritos.</p>
+	{/if}
+</div>
+
+```
+
+---
+
+## src/routes/profile/+page.svelte
+
+```svelte
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { browser } from '$app/environment';
+	import posthog from 'posthog-js';
+	import { getAuthContext } from '$lib/auth.svelte';
+
+	const auth = getAuthContext();
+
+	// Redirect to home if not logged in
+	$effect(() => {
+		if (browser && !auth.user) {
+			goto('/');
+		}
+	});
+
+	function triggerTestError() {
+		try {
+			throw new Error('Test error for PostHog error tracking');
+		} catch (err) {
+			posthog.captureException(err);
+			console.error('Captured error:', err);
+			alert('Error captured and sent to PostHog!');
+		}
+	}
+</script>
+
+<div class="container">
+	{#if auth.user}
+		<h1>User profile</h1>
+
+		<div class="stats">
+			<h2>Your information</h2>
+			<p><strong>Username:</strong> {auth.user.username}</p>
+			<p><strong>Burrito considerations:</strong> {auth.user.burritoConsiderations}</p>
+		</div>
+
+		<h2 style="margin-top: 2rem;">Error tracking demo</h2>
+		<p>Click the button below to trigger a test error that will be captured by PostHog.</p>
+
+		<button class="btn-primary" onclick={triggerTestError} style="margin-top: 1rem;">
+			Trigger test error (for PostHog)
+		</button>
+
+		<div class="note">
+			<p>This demonstrates PostHog's error tracking capabilities.</p>
+			<p>The error will appear in your PostHog error tracking dashboard.</p>
+		</div>
+	{:else}
+		<p>Please log in to view your profile.</p>
+	{/if}
+</div>
+
+```
+
+---
+
+## static/robots.txt
+
+```txt
+# allow crawling everything by default
+User-agent: *
+Disallow:
+
+```
+
+---
+
+## svelte.config.js
+
+```js
+import adapter from '@sveltejs/adapter-auto';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	// Consult https://svelte.dev/docs/kit/integrations
+	// for more information about preprocessors
+	preprocess: vitePreprocess(),
+
+	kit: {
+		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
+		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
+		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
+		adapter: adapter(),
+		// Required for PostHog session replay to work correctly with SSR
+		paths: {
+			relative: false
+		}
+	}
+};
+
+export default config;
+
+```
+
+---
+
+## vite.config.ts
+
+```ts
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [sveltekit()]
+});
+
+```
+
+---
+

--- a/.claude/skills/integration-sveltekit/references/basic-integration-1.0-begin.md
+++ b/.claude/skills/integration-sveltekit/references/basic-integration-1.0-begin.md
@@ -1,0 +1,56 @@
+---
+title: PostHog Setup - Begin
+description: Start the event tracking setup process by analyzing the project and creating an event tracking plan
+---
+
+We're making an event tracking plan for this project.
+
+This is the first of several phases — plan the events, implement them, revise and validate changes, then conclude by creating a dashboard and writing a setup report.
+
+## Task list
+
+As soon as you've read this description and have a rough sense of the work, make a single **call `TaskCreate` immediately** before reading any reference file or beginning analysis. The user is watching the task pane and shouldn't see it sit empty.
+
+It's fine if your first list is incomplete or imprecise. Seed it with whatever high-level items you can infer from the overview above, then call `TaskCreate` again (or `TaskUpdate` to refine existing items) every time your understanding sharpens: after a phase reveals work you didn't anticipate, after planning surfaces concrete sub-items, after you hit something new. Use `TaskUpdate` to mark items `in_progress` when you start them and `completed` when you finish. Keeping the list current matters more than getting it right on the first call.
+
+Keep task titles broad and job-oriented. Describe the purpose or area of work with wording like "Planning event tracking", "Identifying users", "Installing PostHog", "Capturing events", or "Creating dashboards", not the specific files, paths, or symbols involved. Adjust the task names according to the user's project and context.
+
+Before proceeding, find any existing `posthog.capture()` code. Make note of event name formatting.
+
+From the project's file list, select between 10 and 15 files that might have interesting business value for event tracking, especially conversion and churn events. Also look for additional files related to login that could be used for identifying users, along with error handling. Read the files. If a file is already well-covered by PostHog events, replace it with another option. Do not spawn subagents.
+
+Look for opportunities to track client-side events.
+
+**IMPORTANT: Server-side events are REQUIRED** if the project includes any instrumentable server-side code. If the project has API routes (e.g., `app/api/**/route.ts`) or Server Actions, you MUST include server-side events for critical business operations like:
+
+  - Payment/checkout completion
+  - Webhook handlers
+  - Authentication endpoints
+
+Do not skip server-side events - they capture actions that cannot be tracked client-side.
+
+Create a new file with a JSON array at the root of the project: .posthog-events.json. It should include one object for each event we want to add: event name, event description, and the file path we want to place the event in. If events already exist, don't duplicate them; supplement them.
+
+Track actions only, not pageviews. These can be captured automatically. Exceptions can be made for "viewed"-type events that correspond to the top of a conversion funnel.
+
+As you review files, make an internal note of opportunities to identify users and catch errors. We'll need them for the next step.
+
+## Status
+
+Before beginning a phase of the setup, you will send a status message with the exact prefix '[STATUS]', as in:
+
+[STATUS] Checking project structure.
+
+Status to report in this phase:
+
+- Checking project structure
+- Verifying PostHog dependencies
+- Generating events based on project
+
+## Abort statuses
+
+If and only if the instructions have `[ABORT]` states specified, and you clearly match the conditions for an abort, emit the abort message. Do NOT attempt to exit or halt yourself — the wizard's middleware catches `[ABORT]` and terminates the run for you.
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.1-edit.md](basic-integration-1.1-edit.md)

--- a/.claude/skills/integration-sveltekit/references/basic-integration-1.1-edit.md
+++ b/.claude/skills/integration-sveltekit/references/basic-integration-1.1-edit.md
@@ -1,0 +1,37 @@
+---
+title: PostHog Setup - Edit
+description: Implement PostHog event tracking in the identified files, following best practices and the example project
+---
+
+For each of the files and events noted in .posthog-events.json, make edits to capture events using PostHog. Make sure to set up any helper files needed. Carefully examine the included example project code: your implementation should match it as closely as possible. Do not spawn subagents.
+
+Use environment variables for PostHog keys. Do not hardcode PostHog keys.
+
+If a file already has existing integration code for other tools or services, don't overwrite or remove that code. Place PostHog code below it.
+
+For each event, add useful properties, and use your access to the PostHog source code to ensure correctness. You also have access to documentation about creating new events with PostHog. Consider this documentation carefully and follow it closely before adding events. Your integration should be based on documented best practices. Carefully consider how the user project's framework version may impact the correct PostHog integration approach.
+
+Remember that you can find the source code for any dependency in the node_modules directory. This may be necessary to properly populate property names. There are also example project code files available via the PostHog MCP; use these for reference.
+
+Where possible, add calls for PostHog's identify() function on the client side upon events like logins and signups. Use the contents of login and signup forms to identify users on submit. If there is server-side code, pass the client-side session and distinct ID to the server-side code to identify the user. On the server side, make sure events have a matching distinct ID where relevant. 
+
+It's essential to do this in both client code and server code, so that user behavior from both domains is easy to correlate.
+
+You should also add PostHog exception capture error tracking to these files where relevant.
+
+Remember: Do not alter the fundamental architecture of existing files. Make your additions minimal and targeted.
+
+Remember the documentation and example project resources you were provided at the beginning. Read them now.
+
+## Status
+
+Status to report in this phase:
+
+- Inserting PostHog capture code
+- A status message for each file whose edits you are planning, including a high level summary of changes
+- A status message for each file you have edited
+
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.2-revise.md](basic-integration-1.2-revise.md)

--- a/.claude/skills/integration-sveltekit/references/basic-integration-1.2-revise.md
+++ b/.claude/skills/integration-sveltekit/references/basic-integration-1.2-revise.md
@@ -1,0 +1,22 @@
+---
+title: PostHog Setup - Revise
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Check the project for errors. Read the package.json file for any type checking or build scripts that may provide input about what to fix. Remember that you can find the source code for any dependency in the node_modules directory. Do not spawn subagents.
+
+Ensure that any components created were actually used.
+
+Once all other tasks are complete, run any linter or prettier-like scripts found in the package.json, but ONLY on the files you have edited or created during this session. Do not run formatting or linting across the entire project's codebase.
+
+## Status
+
+Status to report in this phase:
+
+- Finding and correcting errors
+- Report details of any errors you fix
+- Linting, building and prettying
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.3-conclude.md](basic-integration-1.3-conclude.md)

--- a/.claude/skills/integration-sveltekit/references/basic-integration-1.3-conclude.md
+++ b/.claude/skills/integration-sveltekit/references/basic-integration-1.3-conclude.md
@@ -1,0 +1,40 @@
+---
+title: PostHog Setup - Conclusion
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Use the PostHog MCP to create a new dashboard named "Analytics basics (wizard)" based on the events created here. Keep the `(wizard)` tag with that exact casing so anyone browsing PostHog can see the wizard created this dashboard, and so a quick search for `(wizard)` surfaces every wizard-created artifact in one go. Make sure to use the exact same event names as implemented in the code. Populate it with up to five insights, with special emphasis on things like conversion funnels, churn events, and other business critical insights.  
+
+Search for a file called `.posthog-events.json` and read it for available events.
+
+Do not spawn subagents.
+
+Create the file posthog-setup-report.md. It should include a summary of the integration edits, a table with the event names, event descriptions, and files where events were added, along with a list of links for the dashboard and insights created. Follow this format:
+
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of your project. [Detailed summary of changes]
+
+[table of events/descriptions/files]
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+[links]
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>
+
+Upon completion, remove .posthog-events.json.
+
+## Status
+
+Status to report in this phase:
+
+- Configured dashboard: [insert PostHog dashboard URL]
+- Created setup report: [insert full local file path]

--- a/.claude/skills/integration-sveltekit/references/identify-users.md
+++ b/.claude/skills/integration-sveltekit/references/identify-users.md
@@ -1,0 +1,271 @@
+# Identify users - Docs
+
+Linking events to specific users enables you to build a full picture of how they're using your product across different sessions, devices, and platforms.
+
+This is straightforward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js.md), as you associate events to a specific user using a `distinct_id`, which is a required argument.
+
+However, in the frontend of a [web](/docs/libraries/js/features.md#capturing-events) or [mobile app](/docs/libraries/ios.md#capturing-events), a `distinct_id` is not a required argument — PostHog's SDKs will generate an anonymous `distinct_id` for you automatically and you can capture events anonymously, provided you use the appropriate [configuration](/docs/libraries/js/features.md#capturing-anonymous-events).
+
+To link events to specific users, call `identify`:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.identify(
+  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional person properties
+);
+```
+
+### Android
+
+```kotlin
+PostHog.identify(
+    distinctId = distinctID, // Replace 'distinctID' with your user's unique identifier
+    // optional: set additional person properties
+    userProperties = mapOf(
+        "name" to "Max Hedgehog",
+        "email" to "max@hedgehogmail.com"
+    )
+)
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
+                           userProperties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional person properties
+```
+
+### React Native
+
+```jsx
+posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
+    email: 'max@hedgehogmail.com', // optional: set additional person properties
+    name: 'Max Hedgehog'
+})
+```
+
+### Dart
+
+```dart
+await Posthog().identify(
+  userId: 'distinct_id', // Replace "distinct_id" with your user's unique identifier
+  userProperties: {
+    email: "max@hedgehogmail.com", // optional: set additional person properties
+    name: "Max Hedgehog"
+});
+```
+
+Events captured after calling `identify` are identified events and this creates a person profile if one doesn't exist already.
+
+Due to the cost of processing them, anonymous events can be up to 4x cheaper than identified events, so it's recommended you only capture identified events when needed.
+
+## How identify works
+
+When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally.
+
+Provided you've [configured persistence](/docs/libraries/js/persistence.md) to use cookies or `localStorage`, this enables us to track anonymous users – even across different sessions.
+
+By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
+
+Thus, all past and future events made with that anonymous ID are now associated with the distinct ID.
+
+This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
+
+Using identify in the backend
+
+Although you can call `identify` using our backend SDKs, it is used most in frontends. This is because there is no concept of anonymous sessions in the backend SDKs, so calling `identify` only updates person profiles.
+
+## Best practices when using `identify`
+
+### 1\. Call `identify` as soon as you're able to
+
+In your frontend, you should call `identify` as soon as you're able to.
+
+Typically, this is every time your **app loads** for the first time, and directly after your **users log in**.
+
+This ensures that events sent during your users' sessions are correctly associated with them.
+
+You only need to call `identify` once per session, and you should avoid calling it multiple times unnecessarily.
+
+If you call `identify` multiple times with the same data without reloading the page in between, PostHog will ignore the subsequent calls.
+
+### 2\. Use unique strings for distinct IDs
+
+If two users have the same distinct ID, their data is merged and they are considered one user in PostHog. Two common ways this can happen are:
+
+-   Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+-   There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
+
+PostHog also has built-in protections to stop the most common distinct ID mistakes.
+
+### 3\. Reset after logout
+
+If a user logs out on your frontend, you should call `reset()` to unlink any future events made on that device with that user.
+
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions.
+
+**We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
+
+You can do that like so:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.reset()
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.reset()
+```
+
+### Android
+
+```kotlin
+PostHog.reset()
+```
+
+### React Native
+
+```jsx
+posthog.reset()
+```
+
+### Dart
+
+```dart
+Posthog().reset()
+```
+
+If you *also* want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.reset(true)
+```
+
+### 4\. Person profiles and properties
+
+You'll notice that one of the parameters in the `identify` method is a `properties` object.
+
+This enables you to set [person properties](/docs/product-analytics/person-properties.md).
+
+Whenever possible, we recommend passing in all person properties you have available each time you call identify, as this ensures their person profile on PostHog is up to date.
+
+Person properties can also be set being adding a `$set` property to a event `capture` call.
+
+See our [person properties docs](/docs/product-analytics/person-properties.md) for more details on how to work with them and best practices.
+
+### 5\. Use deep links between platforms
+
+We recommend you call `identify` [as soon as you're able](#1-call-identify-as-soon-as-youre-able), typically when a user signs up or logs in.
+
+This doesn't work if one or both platforms are unauthenticated. Some examples of such cases are:
+
+-   Onboarding and signup flows before authentication.
+-   Unauthenticated web pages redirecting to authenticated mobile apps.
+-   Authenticated web apps prompting an app download.
+
+In these cases, you can use a [deep link](https://developer.android.com/training/app-links/deep-linking) on Android and [universal links](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app) on iOS to identify users.
+
+1.  Use `posthog.get_distinct_id()` to get the current distinct ID. Even if you cannot call identify because the user is unauthenticated, this will return an anonymous distinct ID generated by PostHog.
+2.  Add the distinct ID to the deep link as query parameters, along with other properties like UTM parameters.
+3.  When the user is redirected to the app, parse the deep link and handle the following cases:
+
+-   The mobile app is already authenticated. In this case, call [`posthog.alias()`](/docs/libraries/js/features.md#alias) with the distinct ID from the web. This associates the two distinct IDs as a single person.
+-   The mobile app is unauthenticated. In this case, call [`posthog.identify()`](/docs/libraries/js/features.md#identifying-users) with the distinct ID from the web so pre-login mobile events stay connected to the web session. When the user later logs in on mobile, call `identify()` again with your canonical user ID.
+
+As long as you associate the distinct IDs with `posthog.identify()` or `posthog.alias()`, you can track events generated across platforms.
+
+Here's an example implementation for handling deep links from web to mobile:
+
+PostHog AI
+
+### iOS
+
+```swift
+import PostHog
+class DeepLinkIdentityManager {
+    static let shared = DeepLinkIdentityManager()
+    // MARK: - Deep Link Received
+    func handleDeepLink(_ url: URL, isAuthenticatedOnMobile: Bool) {
+        guard let webDistinctId = URLComponents(url: url, resolvingAgainstBaseURL: true)?
+            .queryItems?.first(where: { $0.name == "ph_distinct_id" })?.value else {
+            return
+        }
+        if isAuthenticatedOnMobile {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHogSDK.shared.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHogSDK.shared.identify(webDistinctId)
+        }
+    }
+    // MARK: - Login/Signup
+    func handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHogSDK.shared.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    func handleLogout() {
+        PostHogSDK.shared.reset()
+    }
+}
+```
+
+### Android
+
+```kotlin
+import android.net.Uri
+import com.posthog.PostHog
+object DeepLinkIdentityManager {
+    // Deep Link Received
+    fun handleDeepLink(uri: Uri, isAuthenticatedOnMobile: Boolean) {
+        val webDistinctId = uri.getQueryParameter("ph_distinct_id") ?: return
+        if (isAuthenticatedOnMobile) {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHog.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHog.identify(webDistinctId)
+        }
+    }
+    // Login/Signup
+    fun handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHog.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    fun handleLogout() {
+        PostHog.reset()
+    }
+}
+```
+
+## Further reading
+
+-   [Identifying users docs](/docs/product-analytics/identify.md)
+-   [How person processing works](/docs/how-posthog-works/ingestion-pipeline.md#2-person-processing)
+-   [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/integration-sveltekit/references/svelte.md
+++ b/.claude/skills/integration-sveltekit/references/svelte.md
@@ -1,0 +1,234 @@
+# Svelte - Docs
+
+PostHog makes it easy to get data about traffic and usage of your [Svelte](https://svelte.dev/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
+
+This guide walks you through integrating PostHog into your SvelteKit app using the [JavaScript Web](/docs/libraries/js.md) and [Node.js](/docs/libraries/node.md) SDKs.
+
+## Beta: integration via LLM
+
+Install PostHog for Svelte in seconds with our wizard by running this prompt with [LLM coding agents](/blog/envoy-wizard-llm-agent.md) like Cursor and Bolt, or by running it in your terminal.
+
+`npx @posthog/wizard@latest`
+
+[Learn more](/wizard.md)
+
+Or, to integrate manually, continue with the rest of this guide.
+
+## Client-side setup
+
+Install `posthog-js` using your package manager:
+
+PostHog AI
+
+### npm
+
+```bash
+npm install --save posthog-js
+```
+
+### Yarn
+
+```bash
+yarn add posthog-js
+```
+
+### pnpm
+
+```bash
+pnpm add posthog-js
+```
+
+### Bun
+
+```bash
+bun add posthog-js
+```
+
+Then, if you haven't created a root [layout](https://kit.svelte.dev/docs/routing#layout) already, create a new file called `+layout.js` in your `src/routes` folder In this file, check the environment is the browser, and initialize PostHog if so. You can get both your API key and instance address in your [project settings](https://us.posthog.com/project/settings).
+
+routes/+layout.js
+
+PostHog AI
+
+```javascript
+import posthog from 'posthog-js'
+import { browser } from '$app/environment';
+export const load = async () => {
+  if (browser) {
+    posthog.init('<ph_project_token>', {
+      api_host: 'https://us.i.posthog.com',
+      defaults: '2026-01-30',
+    })
+  }
+  return
+};
+```
+
+## Identifying users
+
+> **Identifying users is required.** Call `posthog.identify('your-user-id')` after login to link events to a known user. This is what connects frontend event captures, [session replays](/docs/session-replay.md), [LLM traces](/docs/ai-engineering.md), and [error tracking](/docs/error-tracking.md) to the same person — and lets backend events link back too.
+>
+> See our guide on [identifying users](/docs/getting-started/identify-users.md) for how to set this up.
+
+> ❗️ If you intend on using session replays with a server-side rendered Svelte app ensure that your [asset URLs are configured to be relative](/docs/session-replay/troubleshooting.md#ensure-assets-are-imported-from-the-base-URL-in-Svelte).
+
+Set up a reverse proxy (recommended)
+
+We recommend [setting up a reverse proxy](/docs/advanced/proxy.md), so that events are less likely to be intercepted by tracking blockers.
+
+We have our [own managed reverse proxy service](/docs/advanced/proxy/managed-reverse-proxy.md), which is free for all PostHog Cloud users, routes through our infrastructure, and makes setting up your proxy easy.
+
+If you don't want to use our managed service then there are several other options for creating a reverse proxy, including using [Cloudflare](/docs/advanced/proxy/cloudflare.md), [AWS Cloudfront](/docs/advanced/proxy/cloudfront.md), and [Vercel](/docs/advanced/proxy/vercel.md).
+
+Grouping products in one project (recommended)
+
+If you have multiple customer-facing products (e.g. a marketing website + mobile app + web app), it's best to install PostHog on them all and [group them in one project](/docs/settings/projects.md).
+
+This makes it possible to track users across their entire journey (e.g. from visiting your marketing website to signing up for your product), or how they use your product across multiple platforms.
+
+Add IPs to Firewall/WAF allowlists (recommended)
+
+For certain features like [heatmaps](/docs/toolbar/heatmaps.md), your Web Application Firewall (WAF) may be blocking PostHog’s requests to your site. Add these IP addresses to your WAF allowlist or rules to let PostHog access your site.
+
+**EU**: `3.75.65.221`, `18.197.246.42`, `3.120.223.253`
+
+**US**: `44.205.89.55`, `52.4.194.122`, `44.208.188.173`
+
+These are public, stable IPs used by PostHog services (e.g., Celery tasks for snapshots).
+
+## Server-side setup
+
+Install `posthog-node` using your package manager:
+
+PostHog AI
+
+### npm
+
+```bash
+npm install posthog-node --save
+```
+
+### Yarn
+
+```bash
+yarn add posthog-node
+```
+
+### pnpm
+
+```bash
+pnpm add posthog-node
+```
+
+### Bun
+
+```bash
+bun add posthog-node
+```
+
+Then, initialize the PostHog Node client where you'd like to use it on the server side. For example, in a [load function](https://kit.svelte.dev/docs/load#page-data):
+
+routes/+page.server.js
+
+PostHog AI
+
+```javascript
+import { PostHog } from 'posthog-node';
+export async function load() {
+  const posthog = new PostHog('<ph_project_token>', { host: 'https://us.i.posthog.com' });
+  posthog.capture({
+    distinctId: 'distinct_id_of_the_user',
+    event: 'event_name',
+  })
+  await posthog.shutdown()
+}
+```
+
+> **Note:** Make sure to always call `posthog.shutdown()` after capturing events from the server-side. PostHog queues events into larger batches, and this call forces all batched events to be flushed immediately.
+
+## Feature flags
+
+To use client-side feature flags, import PostHog into your Svelte component and check if the feature is enabled (while ensuring the code only runs in the browser).
+
+routes/+page.svelte
+
+PostHog AI
+
+```javascript
+<script>
+  import posthog from 'posthog-js'
+  import { browser } from '$app/environment'
+  import { onMount } from 'svelte'
+  let coolFeature = $state(false)
+  onMount(() => {
+    if (browser) {
+      coolFeature = posthog.isFeatureEnabled('cool-feature')
+    }
+  })
+</script>
+{#if coolFeature}
+  <p>Welcome to the cool feature!</p>
+{/if}
+```
+
+To use server-side feature flags, import PostHog into your SvelteKit `load` function and check if the feature is enabled.
+
+routes/+page.server.js
+
+PostHog AI
+
+```javascript
+import { PostHog } from 'posthog-node';
+const client = new PostHog(
+  '<ph_project_token>',
+  { host: 'https://us.i.posthog.com' }
+);
+export async function load() {
+  const distinctId = 'distinct_id_of_the_user';
+  const megaFeature = await client.isFeatureEnabled(
+    'mega-feature',
+    distinctId
+  );
+  return {
+    megaFeature
+  };
+}
+```
+
+See our [JavaScript Web](/docs/libraries/js/features.md#feature-flags) and [Node](/docs/libraries/node.md#feature-flags) docs for more details.
+
+## Configuring session replay for server-side rendered apps
+
+By default, [Svelte uses relative asset paths](https://kit.svelte.dev/docs/configuration) during server-side rending. This causes issues with PostHog's ability to record sessions.
+
+To fix this, set the config to not use relative paths in `svelte.config.js`:
+
+JavaScript
+
+PostHog AI
+
+```javascript
+kit: {
+     paths: {
+         relative: false,
+     },
+ },
+```
+
+## Next steps
+
+For any technical questions for how to integrate specific PostHog features into Svelte (such as analytics, feature flags, A/B testing, surveys, etc.), have a look at our [JavaScript Web](/docs/libraries/js/features.md) and [Node]((/docs/libraries/node)) SDK docs.
+
+Alternatively, the following tutorials can help you get started:
+
+-   [How to set up Svelte analytics, feature flags, and more](/tutorials/svelte-analytics.md)
+-   [How to set up A/B tests in Svelte](/tutorials/svelte-ab-tests.md)
+-   [How to set up surveys in Svelte](/tutorials/svelte-surveys.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,8 @@
 				"nodemailer": "^6.10.0",
 				"perfect-freehand": "^1.2.2",
 				"playht": "^0.9.8",
+				"posthog-js": "^1.386.6",
+				"posthog-node": "^5.37.0",
 				"redis": "^5.10.0",
 				"resize-observer-polyfill": "^1.5.1",
 				"stripe": "^16.6.0",
@@ -4097,6 +4099,21 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
 			"integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw=="
 		},
+		"node_modules/@posthog/core": {
+			"version": "1.32.3",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.32.3.tgz",
+			"integrity": "sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==",
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/types": "1.386.3"
+			}
+		},
+		"node_modules/@posthog/types": {
+			"version": "1.386.3",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.386.3.tgz",
+			"integrity": "sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==",
+			"license": "MIT"
+		},
 		"node_modules/@prettier/plugin-xml": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-2.2.0.tgz",
@@ -6748,7 +6765,7 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/uuid": {
@@ -8724,6 +8741,17 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/core-js": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
+		},
 		"node_modules/core-js-compat": {
 			"version": "3.47.0",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
@@ -9635,6 +9663,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+			"integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/domutils": {
@@ -10723,6 +10760,12 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+			"license": "MIT"
 		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
@@ -14826,6 +14869,52 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/posthog-js": {
+			"version": "1.386.6",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.386.6.tgz",
+			"integrity": "sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==",
+			"license": "SEE LICENSE IN LICENSE",
+			"dependencies": {
+				"@posthog/core": "^1.32.3",
+				"@posthog/types": "^1.386.3",
+				"core-js": "^3.38.1",
+				"dompurify": "^3.3.2",
+				"fflate": "^0.4.8",
+				"preact": "^10.28.2",
+				"query-selector-shadow-dom": "^1.0.1",
+				"web-vitals": "^5.1.0"
+			}
+		},
+		"node_modules/posthog-node": {
+			"version": "5.37.0",
+			"resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.37.0.tgz",
+			"integrity": "sha512-wFwWGcqAqZ1WJRlNNYc92veV83d1lOQcP4Lq0q7Kar9GdZLPpiFYHeudyybYJnjZjkI9v06vLvY/Og5CZIfByg==",
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/core": "^1.32.3"
+			},
+			"engines": {
+				"node": "^20.20.0 || >=22.22.0"
+			},
+			"peerDependencies": {
+				"rxjs": "^7.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rxjs": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/preact": {
+			"version": "10.29.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+			"integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -15137,6 +15226,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/query-selector-shadow-dom": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+			"integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -18354,6 +18449,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/web-vitals": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+			"integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
@@ -21853,6 +21954,19 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
 			"integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw=="
 		},
+		"@posthog/core": {
+			"version": "1.32.3",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.32.3.tgz",
+			"integrity": "sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==",
+			"requires": {
+				"@posthog/types": "1.386.3"
+			}
+		},
+		"@posthog/types": {
+			"version": "1.386.3",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.386.3.tgz",
+			"integrity": "sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q=="
+		},
 		"@prettier/plugin-xml": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-2.2.0.tgz",
@@ -23597,7 +23711,7 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"dev": true
+			"devOptional": true
 		},
 		"@types/uuid": {
 			"version": "9.0.8",
@@ -24889,6 +25003,11 @@
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
 		},
+		"core-js": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="
+		},
 		"core-js-compat": {
 			"version": "3.47.0",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
@@ -25495,6 +25614,14 @@
 			"dev": true,
 			"requires": {
 				"domelementtype": "^2.2.0"
+			}
+		},
+		"dompurify": {
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+			"integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+			"requires": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"domutils": {
@@ -26262,6 +26389,11 @@
 					"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
 				}
 			}
+		},
+		"fflate": {
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
 		},
 		"file-entry-cache": {
 			"version": "6.0.1",
@@ -29028,6 +29160,34 @@
 				"xtend": "^4.0.0"
 			}
 		},
+		"posthog-js": {
+			"version": "1.386.6",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.386.6.tgz",
+			"integrity": "sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==",
+			"requires": {
+				"@posthog/core": "^1.32.3",
+				"@posthog/types": "^1.386.3",
+				"core-js": "^3.38.1",
+				"dompurify": "^3.3.2",
+				"fflate": "^0.4.8",
+				"preact": "^10.28.2",
+				"query-selector-shadow-dom": "^1.0.1",
+				"web-vitals": "^5.1.0"
+			}
+		},
+		"posthog-node": {
+			"version": "5.37.0",
+			"resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.37.0.tgz",
+			"integrity": "sha512-wFwWGcqAqZ1WJRlNNYc92veV83d1lOQcP4Lq0q7Kar9GdZLPpiFYHeudyybYJnjZjkI9v06vLvY/Og5CZIfByg==",
+			"requires": {
+				"@posthog/core": "^1.32.3"
+			}
+		},
+		"preact": {
+			"version": "10.29.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+			"integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="
+		},
 		"prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -29203,6 +29363,11 @@
 			"requires": {
 				"side-channel": "^1.0.6"
 			}
+		},
+		"query-selector-shadow-dom": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+			"integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
@@ -31359,6 +31524,11 @@
 				"vite-node": "1.1.3",
 				"why-is-node-running": "^2.2.2"
 			}
+		},
+		"web-vitals": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+			"integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="
 		},
 		"webidl-conversions": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,8 @@
 		"nodemailer": "^6.10.0",
 		"perfect-freehand": "^1.2.2",
 		"playht": "^0.9.8",
+		"posthog-js": "^1.386.6",
+		"posthog-node": "^5.37.0",
 		"redis": "^5.10.0",
 		"resize-observer-polyfill": "^1.5.1",
 		"stripe": "^16.6.0",

--- a/posthog-setup-report.md
+++ b/posthog-setup-report.md
@@ -1,0 +1,37 @@
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of PostHog into Parallel Arabic. Client-side analytics is initialised in `hooks.client.ts` (with session replay support and automatic exception capture), a reverse proxy is wired into `hooks.server.ts` to avoid ad blockers, and `svelte.config.js` has been updated with `paths.relative: false` as required for session replay with SSR. A server-side PostHog singleton (`src/lib/server/posthog.ts`) is used across 10 API and server files to capture key business events, and `posthog.identify()` / `posthog.reset()` are called in the root layout to correlate client and server activity for each user.
+
+| Event | Description | File |
+|---|---|---|
+| `user_signed_up` | New account created via email/password | `src/routes/signup/+page.server.ts` |
+| `user_signed_up` | New account created via Google OAuth | `src/routes/api/auth/google/callback/+server.ts` |
+| `user_logged_in` | Successful email/password login | `src/routes/login/+page.server.ts` |
+| `user_logged_in` | Successful Google OAuth login | `src/routes/api/auth/google/callback/+server.ts` |
+| `user_logged_out` | User logged out | `src/routes/auth/logout/+server.ts` |
+| `onboarding_completed` | User finished onboarding (dialect, level, reason) | `src/routes/api/onboarding/+server.ts` |
+| `subscription_started` | Payment confirmed, user subscribed | `src/routes/pricing/subscribed/+page.server.ts` |
+| `subscription_cancelled` | User cancelled their subscription | `src/routes/api/cancel-subscription/+server.ts` |
+| `lesson_started` | User started a structured lesson | `src/routes/api/structured-lessons/start/+server.ts` |
+| `word_saved` | User saved a vocabulary word to their deck | `src/routes/api/save-word/+server.ts` |
+| `word_reviewed` | User completed a spaced-repetition word review | `src/routes/api/review-word/+server.ts` |
+| `tutor_session_saved` | User saved an AI tutor conversation session | `src/routes/api/tutor-save-session/+server.ts` |
+| `server_error` | Server-side unhandled error | `src/hooks.server.ts` |
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+- [Analytics basics (wizard) — Dashboard](https://us.posthog.com/project/467800/dashboard/1705934)
+- [New signups over time](https://us.posthog.com/project/467800/insights/LfUKungQ)
+- [Signup to subscription conversion funnel](https://us.posthog.com/project/467800/insights/KVvWoksM)
+- [Subscription churn trend](https://us.posthog.com/project/467800/insights/UKfq6nbA)
+- [Learning engagement over time](https://us.posthog.com/project/467800/insights/4WhbUeOu)
+- [Tutor session saves over time](https://us.posthog.com/project/467800/insights/3TLAS3x9)
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,3 +1,7 @@
+import posthog from 'posthog-js';
+import { PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public';
+import type { HandleClientError } from '@sveltejs/kit';
+
 // import * as Sentry from '@sentry/sveltekit';
 // import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 
@@ -19,6 +23,17 @@
 // });
 // console.log('[Sentry] DSN present:', !!import.meta.env.PUBLIC_SENTRY_DSN);
 
-export const handleError = ({ error }: { error: unknown }) => {
+export async function init() {
+	posthog.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+		api_host: '/ingest',
+		ui_host: 'https://us.posthog.com',
+		defaults: '2026-01-30',
+		capture_exceptions: true
+	});
+}
+
+export const handleError: HandleClientError = async ({ error, status, message }) => {
+	posthog.captureException(error);
 	console.error(error);
+	return { message, status };
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,11 +1,49 @@
 // import * as Sentry from '@sentry/sveltekit';
 import { createServerClient } from '@supabase/ssr';
-import { redirect, type Handle } from '@sveltejs/kit';
+import { redirect, type Handle, type HandleServerError } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
+import { getPostHogClient } from '$lib/server/posthog';
 import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
 import { dev } from '$app/environment';
 
 const DIALECTS = ['egyptian-arabic', 'darija', 'levantine', 'fusha'];
+
+const posthogProxy: Handle = async ({ event, resolve }) => {
+	const { pathname } = event.url;
+
+	if (pathname.startsWith('/ingest')) {
+		const useAssetHost =
+			pathname.startsWith('/ingest/static/') || pathname.startsWith('/ingest/array/');
+		const hostname = useAssetHost ? 'us-assets.i.posthog.com' : 'us.i.posthog.com';
+
+		const url = new URL(event.request.url);
+		url.protocol = 'https:';
+		url.hostname = hostname;
+		url.port = '443';
+		url.pathname = pathname.replace(/^\/ingest/, '');
+
+		const headers = new Headers(event.request.headers);
+		headers.set('host', hostname);
+		headers.set('accept-encoding', '');
+
+		const clientIp = event.request.headers.get('x-forwarded-for') || event.getClientAddress();
+		if (clientIp) {
+			headers.set('x-forwarded-for', clientIp);
+		}
+
+		const response = await fetch(url.toString(), {
+			method: event.request.method,
+			headers,
+			body: event.request.body,
+			// @ts-expect-error - duplex is required for streaming request bodies
+			duplex: 'half'
+		});
+
+		return response;
+	}
+
+	return resolve(event);
+};
 
 const redirects: Handle = async ({ event, resolve }) => {
 	const { pathname } = event.url;
@@ -42,8 +80,19 @@ const redirects: Handle = async ({ event, resolve }) => {
 // 	tracesSampleRate: 1.0
 // });
 
-export const handleError = ({ error }: { error: unknown }) => {
+export const handleError: HandleServerError = async ({ error, status, message }) => {
+	const posthog = getPostHogClient();
+	posthog.capture({
+		distinctId: 'server',
+		event: 'server_error',
+		properties: {
+			error: error instanceof Error ? error.message : String(error),
+			status,
+			message
+		}
+	});
 	console.error(error);
+	return { message, status };
 };
 // export const handleError = Sentry.handleErrorWithSentry();
 
@@ -197,5 +246,5 @@ const auth: Handle = async ({ event, resolve }) => {
 	return resolve(event);
 };
 
-export const handle: Handle = sequence(redirects, supabase, authGuard, auth);
+export const handle: Handle = sequence(posthogProxy, redirects, supabase, authGuard, auth);
 // export const handle: Handle = sequence(Sentry.sentryHandle(), redirects, supabase, authGuard, auth);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,16 @@
+import { browser } from '$app/environment';
+import posthog from 'posthog-js';
+
+/**
+ * Thin client-side wrapper around posthog.capture. Single chokepoint for
+ * semantic product events so we don't scatter raw posthog calls, and so
+ * analytics can never break the app (SSR-safe + swallows errors).
+ */
+export function trackEvent(event: string, properties?: Record<string, unknown>) {
+	if (!browser) return;
+	try {
+		posthog.capture(event, properties);
+	} catch {
+		// never let analytics break the app
+	}
+}

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -50,7 +50,7 @@
           {#snippet children()}
             <span class="cursor-help hover:scale-110 inline-block transition-transform duration-200">حُبّ</span>
           {/snippet}
-        </Tooltip> by <a href="https://sherifelmetwally.com/" target="_blank" class="hover:text-text-100 font-medium transition-colors duration-200">Sherif Elmetwally</a>
+        </Tooltip> by <a href="https://arabic-for-nerds.com/interviews/9273-roots/interview-sherif-elmetwally/" target="_blank" class="hover:text-text-100 font-medium transition-colors duration-200">Sherif Elmetwally</a>
       </p>
     </div>
   </div>

--- a/src/lib/components/StoryAudioButton.svelte
+++ b/src/lib/components/StoryAudioButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Howl } from 'howler';
   import type { Dialect } from '$lib/types/index';
+  import { trackEvent } from '$lib/analytics';
 
   interface StorySentence {
     arabic: { text: string };
@@ -153,6 +154,9 @@
   }
 
   function toggleStoryAudio() {
+    if (!isPlaying) {
+      trackEvent('story_audio_played', { story_id: storyId, dialect, playback_rate: playbackRate });
+    }
     // If currently playing, pause
     if (isPlaying && currentSound && currentSound.playing()) {
       currentSound.pause();

--- a/src/lib/components/dialect-shared/lesson/InteractiveExercise.svelte
+++ b/src/lib/components/dialect-shared/lesson/InteractiveExercise.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import InlineAudioButton from '$lib/components/InlineAudioButton.svelte';
 	import type { Dialect } from '$lib/types/index';
+	import { trackEvent } from '$lib/analytics';
 
 	interface Exercise {
 		id: string;
@@ -72,6 +73,7 @@
 		);
 		isCorrect = selectedOption?.isCorrect || false;
 		showResult = true;
+		trackEvent('lessons_exercise_submitted', { exercise_type: 'multiple-choice', is_correct: isCorrect, dialect });
 	}
 
 
@@ -134,6 +136,7 @@
 		isCorrect = allCorrect;
 		showResult = true;
 		allMatched = true;
+		trackEvent('lessons_exercise_submitted', { exercise_type: 'matching', is_correct: isCorrect, dialect });
 	}
 
 	function handleFillInBlank(blankIndex: number, optionValue: string) {
@@ -172,6 +175,7 @@
 		
 		isCorrect = allCorrect;
 		showResult = true;
+		trackEvent('lessons_exercise_submitted', { exercise_type: 'fill-in-blank', is_correct: isCorrect, dialect });
 	}
 
 	function resetExercise() {

--- a/src/lib/components/dialect-shared/sentences/SentenceBlock.svelte
+++ b/src/lib/components/dialect-shared/sentences/SentenceBlock.svelte
@@ -30,6 +30,7 @@
 	import AudioButton from '$lib/components/AudioButton.svelte';
 	import { normalizeArabicText, normalizeArabicTextLight, filterArabicCharacters } from '$lib/utils/arabic-normalization';
 	import type { DialectComparisonSchema } from '$lib/utils/gemini-schemas';
+	import { trackEvent } from '$lib/analytics';
 
 	interface Props {
 		sentence: {
@@ -66,6 +67,7 @@
 	$effect(() => {
 		if (isCorrect && !xpAwardedThisSentence) {
 			xpAwardedThisSentence = true;
+			trackEvent('sentences_typing_completed_correct', { dialect });
 			fetch('/api/award-xp', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
@@ -100,10 +102,12 @@
 
 	async function handleToggleHint() {
 		showHint = !showHint;
+		trackEvent('sentences_hint_toggled', { visible: showHint });
 	}
-	
+
 	async function handleToggleAnswer() {
 		showAnswer = !showAnswer;
+		trackEvent('sentences_answer_toggled', { visible: showAnswer });
 	}
 	let isLoadingDefinition = $state(false);
 	let definition = $state('');
@@ -147,6 +151,7 @@
 	}
 
 	async function compareDialects() {
+		trackEvent('sentences_dialect_comparison_opened', { dialect });
 		isComparing = true;
 		isComparisonModalOpen = true;
 		comparisonData = null;
@@ -374,6 +379,7 @@
 		// Map English words to Arabic equivalent and filter for Arabic characters only
 		targetArabicWord = mapEnglishToArabic(wordsArray);
 		const isSingleWordDefinition = wordsArray.length === 1 && countTokens(targetArabicWord) === 1;
+		trackEvent('sentences_definition_requested', { single_word: isSingleWordDefinition, dialect });
 
 		isLoadingDefinition = true;
 		openDefinitionModal();
@@ -511,6 +517,7 @@
 	
 	function clearReorderSelection() {
 		if (reorderChecked) return;
+		trackEvent('sentences_reorder_cleared', { dialect });
 		initializeShuffledWords();
 		selectedReorderWords = [];
 	}
@@ -518,26 +525,29 @@
 	function checkReorderAnswer() {
 		const userAnswer = selectedReorderWords.join(' ');
 		const correctAnswer = sentence.arabic;
-		
+
 		// Use normalization for comparison
 		const normalizedUser = normalizeArabicText(userAnswer);
 		const normalizedCorrect = normalizeArabicText(correctAnswer);
-		
+
 		reorderCorrect = normalizedUser === normalizedCorrect;
 		reorderChecked = true;
 		isCorrect = reorderCorrect;
+		trackEvent('sentences_reorder_submitted', { correct: reorderCorrect, dialect });
 	}
-	
+
 	function resetReorder() {
+		trackEvent('sentences_reorder_retry', { dialect });
 		initializeShuffledWords();
 		selectedReorderWords = [];
 		reorderChecked = false;
 		reorderCorrect = false;
 		isCorrect = false;
 	}
-	
+
 	// Reset mode-specific state when mode changes
 	function handleModeChange(newMode: PracticeMode) {
+		trackEvent('sentences_practice_mode_changed', { practice_mode: newMode });
 		practiceMode = newMode;
 		isCorrect = false;
 		
@@ -820,7 +830,7 @@
 			</button>
 			{#if sentence.arabicTashkeel}
 			<button
-				onclick={() => showTashkeel = !showTashkeel}
+				onclick={() => { showTashkeel = !showTashkeel; trackEvent('sentences_tashkeel_toggled', { visible: showTashkeel }); }}
 				class="flex items-center gap-1.5 px-3 py-2 text-sm font-semibold rounded-lg transition-all duration-200 {showTashkeel ? 'bg-amber-600 text-white shadow-md' : 'bg-tile-500 text-text-300 hover:bg-tile-600 border border-tile-600'}"
 			>
 				<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -837,6 +847,7 @@
 		<!-- Audio button -->
 		<button 
 			onclick={() => {
+				trackEvent('sentences_audio_played', { dialect });
 				const audioBtn = document.querySelector('.sentence-audio-btn') as HTMLButtonElement;
 				audioBtn?.click();
 			}}

--- a/src/lib/components/dialect-shared/sentences/SentenceQuiz.svelte
+++ b/src/lib/components/dialect-shared/sentences/SentenceQuiz.svelte
@@ -6,6 +6,7 @@
 	import { userXp, userLevel } from '$lib/store/xp-store';
 	import { showXpToast } from '$lib/helpers/toast-helpers';
 	import { LEVEL_TIERS } from '$lib/helpers/xp-levels';
+	import { trackEvent } from '$lib/analytics';
 
 	interface Props {
 		index?: number;
@@ -102,6 +103,7 @@
 			isIncorrect = true;
 			isCorrect = false;
 		}
+		trackEvent('sentences_quiz_answer_selected', { correct: isCorrect });
 	}
 
 	$effect(() => {

--- a/src/lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte
+++ b/src/lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte
@@ -2,6 +2,7 @@
 	import cn from 'classnames';
 	import { askChatGTP } from '../helpers/ask-chat-gpt';
 	import { type Dialect } from '$lib/types/index';
+	import { trackEvent } from '$lib/analytics';
 
 	type TWordAlignment = {
 		arabic: string;
@@ -107,6 +108,7 @@
 	}
 
 	async function fetchDefinition(arabicWord: string, wordAlign?: TWordAlignment) {
+		trackEvent('story_word_definition_requested', { word_arabic: arabicWord, dialect, is_saved_word: isSavedWord(arabicWord) });
 		const cacheKey = `${arabicWord}-arabic-${dialect}`;
 		const cached = wordCache.get(cacheKey);
 

--- a/src/lib/components/dialect-shared/story/components/CreateStoryModal.svelte
+++ b/src/lib/components/dialect-shared/story/components/CreateStoryModal.svelte
@@ -9,6 +9,7 @@
 	import { showStoryCreationToast, showStorySuccessToast, showTranscriptionToast, showTranscriptionSuccessToast, showErrorToast } from '$lib/helpers/toast-helpers';
 	import PaywallModal from '$lib/components/PaywallModal.svelte';
 	import { fetchUserReviewWords } from '$lib/helpers/fetch-review-words';
+	import { trackEvent } from '$lib/analytics';
 
 	let isPaywallModalOpen = $state(false);
 
@@ -63,6 +64,7 @@
 			goto('/signup');
 		}
 		isOpen = true;
+		trackEvent('stories_create_modal_opened', { dialect });
 	}
 
 	function closeModal() {
@@ -322,6 +324,16 @@
 			reviewWords
 		};
 		
+		trackEvent('stories_generation_started', {
+			dialect,
+			story_type: storyType,
+			difficulty: option,
+			sentence_count: sentenceCount,
+			creation_mode: creationMode,
+			use_review_words: useReviewWordsOnly,
+			source: 'create_modal'
+		});
+
 		// Show loading state and keep modal open
 		isLoading = true;
 		isTranscribing = creationMode === 'upload';
@@ -393,6 +405,7 @@
 				}
 
 				// Success! Show success toast with link (no auto-redirect)
+				trackEvent('stories_generation_succeeded', { story_id: storyResult.storyId, dialect: data.dialect, creation_mode: 'upload' });
 				showTranscriptionSuccessToast(processingToastId, storyResult.storyId);
 				
 				// Reset loading states and close modal so user can see the success
@@ -445,6 +458,7 @@
 				}
 
 				// Success! Show success toast with link (no auto-redirect)
+				trackEvent('stories_generation_succeeded', { story_id: chatgptres.storyId, dialect: data.dialect, creation_mode: 'generate' });
 				showStorySuccessToast(processingToastId, data.storyType, chatgptres.storyId);
 				
 				// Reset loading states and close modal so user can see the success
@@ -481,8 +495,9 @@
 			}
 			
 			// Show error toast
+			trackEvent('stories_generation_failed', { error_category: generationError, dialect, creation_mode: creationMode });
 			showErrorToast(processingToastId, generationError, errorDetails);
-			
+
 			// Reset loading states but keep modal open so user can see error and try again
 			isLoading = false;
 			isTranscribing = false;

--- a/src/lib/server/posthog.ts
+++ b/src/lib/server/posthog.ts
@@ -1,0 +1,21 @@
+import { PostHog } from 'posthog-node';
+import { PUBLIC_POSTHOG_PROJECT_TOKEN, PUBLIC_POSTHOG_HOST } from '$env/static/public';
+
+let posthogClient: PostHog | null = null;
+
+export function getPostHogClient() {
+	if (!posthogClient) {
+		posthogClient = new PostHog(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+			host: PUBLIC_POSTHOG_HOST,
+			flushAt: 1,
+			flushInterval: 0
+		});
+	}
+	return posthogClient;
+}
+
+export async function shutdownPostHog() {
+	if (posthogClient) {
+		await posthogClient.shutdown();
+	}
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 	import { pwaInfo } from 'virtual:pwa-info';
 	import { dev, browser } from '$app/environment';
 	import { injectAnalytics } from '@vercel/analytics/sveltekit';
+	import posthog from 'posthog-js';
 	import { getPageMeta, generateStructuredData, formatDialectName } from '$lib/utils/seo';
 	import {
 		importJobStore,
@@ -158,11 +159,26 @@
 			}
 		}
 
+		// Identify user in PostHog when session is available
+		if (data.user?.id) {
+			posthog.identify(data.user.id, { email: data.user.email });
+		}
+
 		// Listen to auth changes and invalidate layout when session changes
 		const { data: authData } = supabase.auth.onAuthStateChange((event: string, newSession: any) => {
-			console.log('[auth state change]', event, 'session:', !!newSession, 'expires_at:', newSession?.expires_at);
+			console.log(
+				'[auth state change]',
+				event,
+				'session:',
+				!!newSession,
+				'expires_at:',
+				newSession?.expires_at
+			);
 			if (newSession?.expires_at !== session?.expires_at) {
 				invalidate('supabase:auth');
+			}
+			if (event === 'SIGNED_OUT') {
+				posthog.reset();
 			}
 		});
 
@@ -228,7 +244,7 @@
 			return 'stories';
 		}
 		if (path.startsWith('/generated_story/')) return 'generated_story';
-	if (path === '/review/import') return 'import';
+		if (path === '/review/import') return 'import';
 		if (path === '/review' || path.startsWith('/review/')) return 'review';
 		if (path === '/tutor') return 'tutor';
 		if (path === '/stories') return 'stories';
@@ -238,7 +254,7 @@
 		if (path === '/vocabulary') return 'vocabulary';
 		if (path === '/about') return 'about';
 		if (path === '/faq') return 'faq';
-return 'home';
+		return 'home';
 	});
 
 	// Get page-specific data from page store
@@ -334,7 +350,9 @@ return 'home';
 			const difficulty = data.storyData.difficulty || '';
 			return generateStructuredData('generated_story', {
 				title: `${englishTitle} / ${arabicTitle} - ${dialectName} Arabic Story`,
-				description: `A ${difficulty} ${dialectName} Arabic story: ${englishTitle}${arabicTitle ? ` / ${arabicTitle}` : ''}`
+				description: `A ${difficulty} ${dialectName} Arabic story: ${englishTitle}${
+					arabicTitle ? ` / ${arabicTitle}` : ''
+				}`
 			});
 		}
 
@@ -427,7 +445,11 @@ return 'home';
 
 <!-- XP Progress Bar - fixed at top (hidden during onboarding) -->
 {#if !showOnboarding}
-	<XpBar loggedIn={!!data.session} initialXp={data.userXp ?? 0} initialLevel={data.userLevel ?? 1} />
+	<XpBar
+		loggedIn={!!data.session}
+		initialXp={data.userXp ?? 0}
+		initialLevel={data.userLevel ?? 1}
+	/>
 {/if}
 
 <!-- Desktop Sidebar -->
@@ -438,7 +460,9 @@ return 'home';
 	<button
 		type="button"
 		onclick={() => sidebarCollapsed.set(false)}
-		class="fixed left-4 z-50 hidden rounded-lg border-2 border-tile-600 bg-tile-500 p-3 text-text-300 shadow-lg transition-all duration-300 hover:bg-tile-600 lg:flex {data.session ? 'top-10' : 'top-4'}"
+		class="fixed left-4 z-50 hidden rounded-lg border-2 border-tile-600 bg-tile-500 p-3 text-text-300 shadow-lg transition-all duration-300 hover:bg-tile-600 lg:flex {data.session
+			? 'top-10'
+			: 'top-4'}"
 		aria-label="Expand sidebar"
 		title="Expand sidebar"
 	>

--- a/src/routes/api/auth/google/callback/+server.ts
+++ b/src/routes/api/auth/google/callback/+server.ts
@@ -1,77 +1,85 @@
 import { redirect } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { syncSupabaseUserWithDB } from '$lib/helpers/supabase-auth-helpers';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
-  console.log('🔗 Google OAuth callback hit');
-  
+	console.log('🔗 Google OAuth callback hit');
+
 	const code = url.searchParams.get('code');
-  const next = url.searchParams.get('next') ?? '/';
-  const error = url.searchParams.get('error');
-  const error_description = url.searchParams.get('error_description');
+	const next = url.searchParams.get('next') ?? '/';
+	const error = url.searchParams.get('error');
+	const error_description = url.searchParams.get('error_description');
 
-  // Handle OAuth errors
-  if (error) {
-    console.error('❌ Google OAuth error:', error, error_description);
-    throw redirect(303, `/login?error=${encodeURIComponent(error_description || error)}`);
-  }
+	// Handle OAuth errors
+	if (error) {
+		console.error('❌ Google OAuth error:', error, error_description);
+		throw redirect(303, `/login?error=${encodeURIComponent(error_description || error)}`);
+	}
 
-  if (!code) {
-    console.error('❌ No OAuth code received');
-    throw redirect(303, '/login?error=No authorization code received');
-  }
+	if (!code) {
+		console.error('❌ No OAuth code received');
+		throw redirect(303, '/login?error=No authorization code received');
+	}
 
-  try {
-    // Exchange the OAuth code for a Supabase session
-    const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
-    
-    if (exchangeError) {
-      console.error('❌ Code exchange error:', exchangeError);
-      throw redirect(303, `/login?error=${encodeURIComponent('Google authentication failed')}`);
-    }
+	try {
+		// Exchange the OAuth code for a Supabase session
+		const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
 
-    if (data.session && data.user) {
-      console.log('✅ Google OAuth successful for:', data.user.email);
-      
-      // Check if this is a new user before syncing
-      const { data: existingUser, error: selectError } = await supabase
-        .from('user')
-        .select('id')
-        .eq('supabase_auth_id', data.user.id)
-        .single()
-      
-      // PGRST116 = no rows returned, meaning it's a new user
-      const isNewUser = !existingUser && selectError?.code === 'PGRST116'
-      
-      try {
-        // Sync user data with your existing database using our helper
-        console.log('🔄 Syncing user with database...');
-        await syncSupabaseUserWithDB(data.user, supabase);
-        console.log('✅ User synced to database:', data.user.email);
-      } catch (syncError) {
-        console.error('❌ Failed to sync user to database:', syncError);
-        // Continue with login even if sync fails - can be retried later
-        // Don't block the user from logging in
-      }
-      
-      // If it's a new user, redirect with newSignup flag to trigger onboarding
-      const redirectUrl = isNewUser ? '/?newSignup=true' : next
-      console.log('🏠 Redirecting to:', redirectUrl);
-      throw redirect(303, redirectUrl);
-    }
-    
-    // No session created
-    console.error('❌ No session created during OAuth exchange');
-    throw redirect(303, '/login?error=Authentication failed');
-    
-  } catch (err) {
-    // Handle any unexpected errors
-    if (err instanceof Response) {
-      // This is a redirect, re-throw it
-      throw err;
-    }
-    
-    console.error('💥 Unexpected error during Google OAuth:', err);
-    throw redirect(303, '/login?error=Authentication failed');
-  }
+		if (exchangeError) {
+			console.error('❌ Code exchange error:', exchangeError);
+			throw redirect(303, `/login?error=${encodeURIComponent('Google authentication failed')}`);
+		}
+
+		if (data.session && data.user) {
+			console.log('✅ Google OAuth successful for:', data.user.email);
+
+			// Check if this is a new user before syncing
+			const { data: existingUser, error: selectError } = await supabase
+				.from('user')
+				.select('id')
+				.eq('supabase_auth_id', data.user.id)
+				.single();
+
+			// PGRST116 = no rows returned, meaning it's a new user
+			const isNewUser = !existingUser && selectError?.code === 'PGRST116';
+
+			try {
+				// Sync user data with your existing database using our helper
+				console.log('🔄 Syncing user with database...');
+				await syncSupabaseUserWithDB(data.user, supabase);
+				console.log('✅ User synced to database:', data.user.email);
+			} catch (syncError) {
+				console.error('❌ Failed to sync user to database:', syncError);
+				// Continue with login even if sync fails - can be retried later
+				// Don't block the user from logging in
+			}
+
+			const posthog = getPostHogClient();
+			posthog.capture({
+				distinctId: data.user.id,
+				event: isNewUser ? 'user_signed_up' : 'user_logged_in',
+				properties: { method: 'google' }
+			});
+			await posthog.flush();
+
+			// If it's a new user, redirect with newSignup flag to trigger onboarding
+			const redirectUrl = isNewUser ? '/?newSignup=true' : next;
+			console.log('🏠 Redirecting to:', redirectUrl);
+			throw redirect(303, redirectUrl);
+		}
+
+		// No session created
+		console.error('❌ No session created during OAuth exchange');
+		throw redirect(303, '/login?error=Authentication failed');
+	} catch (err) {
+		// Handle any unexpected errors
+		if (err instanceof Response) {
+			// This is a redirect, re-throw it
+			throw err;
+		}
+
+		console.error('💥 Unexpected error during Google OAuth:', err);
+		throw redirect(303, '/login?error=Authentication failed');
+	}
 };

--- a/src/routes/api/cancel-subscription/+server.ts
+++ b/src/routes/api/cancel-subscription/+server.ts
@@ -2,48 +2,59 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { supabase } from '$lib/supabaseClient';
 import { StripeService } from '$lib/services/stripe.service';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const POST: RequestHandler = async ({ locals }) => {
-  const { session, user } = await locals.safeGetSession();
+	const { session, user } = await locals.safeGetSession();
 
-  if (!session || !user) {
-    return json({ error: 'You must be logged in to cancel your subscription' }, { status: 401 });
-  }
+	if (!session || !user) {
+		return json({ error: 'You must be logged in to cancel your subscription' }, { status: 401 });
+	}
 
-  // Get the user's subscriber_id
-  const { data: userData, error: fetchError } = await supabase
-    .from('user')
-    .select('subscriber_id')
-    .eq('id', user.id)
-    .single();
+	// Get the user's subscriber_id
+	const { data: userData, error: fetchError } = await supabase
+		.from('user')
+		.select('subscriber_id')
+		.eq('id', user.id)
+		.single();
 
-  if (fetchError) {
-    console.error('Error fetching user:', fetchError);
-    return json({ error: 'Failed to fetch user data' }, { status: 500 });
-  }
+	if (fetchError) {
+		console.error('Error fetching user:', fetchError);
+		return json({ error: 'Failed to fetch user data' }, { status: 500 });
+	}
 
-  if (!userData?.subscriber_id) {
-    return json({ error: 'No active subscription found' }, { status: 400 });
-  }
+	if (!userData?.subscriber_id) {
+		return json({ error: 'No active subscription found' }, { status: 400 });
+	}
 
-  try {
-    // Cancel the subscription at period end
-    const subscription = await StripeService.cancel(userData.subscriber_id);
+	try {
+		// Cancel the subscription at period end
+		const subscription = await StripeService.cancel(userData.subscriber_id);
 
-    if (!subscription) {
-      return json({ error: 'Failed to cancel subscription' }, { status: 500 });
-    }
+		if (!subscription) {
+			return json({ error: 'Failed to cancel subscription' }, { status: 500 });
+		}
 
-    // Return success with the cancellation date
-    return json({
-      success: true,
-      message: 'Subscription will be cancelled at the end of your billing period',
-      cancelAt: subscription.cancel_at,
-      currentPeriodEnd: subscription.current_period_end
-    });
-  } catch (error) {
-    console.error('Error cancelling subscription:', error);
-    return json({ error: 'Failed to cancel subscription' }, { status: 500 });
-  }
+		const posthog = getPostHogClient();
+		posthog.capture({
+			distinctId: user.id,
+			event: 'subscription_cancelled',
+			properties: {
+				cancel_at: subscription.cancel_at,
+				current_period_end: subscription.current_period_end
+			}
+		});
+		await posthog.flush();
+
+		// Return success with the cancellation date
+		return json({
+			success: true,
+			message: 'Subscription will be cancelled at the end of your billing period',
+			cancelAt: subscription.cancel_at,
+			currentPeriodEnd: subscription.current_period_end
+		});
+	} catch (error) {
+		console.error('Error cancelling subscription:', error);
+		return json({ error: 'Failed to cancel subscription' }, { status: 500 });
+	}
 };
-

--- a/src/routes/api/onboarding/+server.ts
+++ b/src/routes/api/onboarding/+server.ts
@@ -1,74 +1,83 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { supabase } from '$lib/supabaseClient';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-  const { sessionId, user } = await locals?.auth?.validate() || {};
+	const { sessionId, user } = (await locals?.auth?.validate()) || {};
 
-  if (!sessionId || !user) {
-    return json({ error: 'You must have an account to onboard' }, { status: 401 });
-  }
+	if (!sessionId || !user) {
+		return json({ error: 'You must have an account to onboard' }, { status: 401 });
+	}
 
-  const { 
-    target_dialect, 
-    learning_reason, 
-    proficiency_level,
-    show_arabic,
-    show_transliteration,
-    show_english
-  } = await request.json();
+	const {
+		target_dialect,
+		learning_reason,
+		proficiency_level,
+		show_arabic,
+		show_transliteration,
+		show_english
+	} = await request.json();
 
-  // Validate inputs
-  const validDialects = ['egyptian-arabic', 'fusha', 'levantine', 'darija'];
-  const validLevels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
+	// Validate inputs
+	const validDialects = ['egyptian-arabic', 'fusha', 'levantine', 'darija'];
+	const validLevels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
 
-  if (!target_dialect || !validDialects.includes(target_dialect)) {
-    return json({ error: 'Invalid dialect' }, { status: 400 });
-  }
+	if (!target_dialect || !validDialects.includes(target_dialect)) {
+		return json({ error: 'Invalid dialect' }, { status: 400 });
+	}
 
-  if (!proficiency_level || !validLevels.includes(proficiency_level)) {
-    return json({ error: 'Invalid proficiency level' }, { status: 400 });
-  }
+	if (!proficiency_level || !validLevels.includes(proficiency_level)) {
+		return json({ error: 'Invalid proficiency level' }, { status: 400 });
+	}
 
-  if (!learning_reason || typeof learning_reason !== 'string') {
-    return json({ error: 'Learning reason is required' }, { status: 400 });
-  }
+	if (!learning_reason || typeof learning_reason !== 'string') {
+		return json({ error: 'Learning reason is required' }, { status: 400 });
+	}
 
-  // Build update data with optional display preferences
-  const updateData: Record<string, string | boolean | number> = {
-    target_dialect,
-    learning_reason,
-    proficiency_level,
-    onboarding_completed: true,
-    onboarding_completed_at: Date.now()
-  };
-  
-  // Add display preferences if provided
-  if (typeof show_arabic === 'boolean') {
-    updateData.show_arabic = show_arabic;
-  }
-  if (typeof show_transliteration === 'boolean') {
-    updateData.show_transliteration = show_transliteration;
-  }
-  if (typeof show_english === 'boolean') {
-    updateData.show_english = show_english;
-  }
+	// Build update data with optional display preferences
+	const updateData: Record<string, string | boolean | number> = {
+		target_dialect,
+		learning_reason,
+		proficiency_level,
+		onboarding_completed: true,
+		onboarding_completed_at: Date.now()
+	};
 
-  try {
-    const { error: updateError } = await supabase
-      .from('user')
-      .update(updateData)
-      .eq('id', user.id);
+	// Add display preferences if provided
+	if (typeof show_arabic === 'boolean') {
+		updateData.show_arabic = show_arabic;
+	}
+	if (typeof show_transliteration === 'boolean') {
+		updateData.show_transliteration = show_transliteration;
+	}
+	if (typeof show_english === 'boolean') {
+		updateData.show_english = show_english;
+	}
 
-    if (updateError) {
-      console.error('Error updating onboarding data:', updateError);
-      return json({ error: 'Failed to save onboarding data' }, { status: 500 });
-    }
+	try {
+		const { error: updateError } = await supabase.from('user').update(updateData).eq('id', user.id);
 
-    return json({ success: true });
-  } catch (e) {
-    console.error('Exception updating onboarding data:', e);
-    return json({ error: 'Something went wrong' }, { status: 500 });
-  }
+		if (updateError) {
+			console.error('Error updating onboarding data:', updateError);
+			return json({ error: 'Failed to save onboarding data' }, { status: 500 });
+		}
+
+		const posthog = getPostHogClient();
+		posthog.capture({
+			distinctId: user.id,
+			event: 'onboarding_completed',
+			properties: {
+				dialect: target_dialect,
+				proficiency_level,
+				learning_reason
+			}
+		});
+		await posthog.flush();
+
+		return json({ success: true });
+	} catch (e) {
+		console.error('Exception updating onboarding data:', e);
+		return json({ error: 'Something went wrong' }, { status: 500 });
+	}
 };
-

--- a/src/routes/api/review-word/+server.ts
+++ b/src/routes/api/review-word/+server.ts
@@ -6,113 +6,130 @@ import { getUserHasActiveSubscription } from '$lib/helpers/get-user-has-active-s
 import { getUserReviewCount } from '$lib/helpers/get-user-review-count';
 import { trackActivitySimple } from '$lib/helpers/track-activity';
 import { v4 as uuidv4 } from 'uuid';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-  const { sessionId, user } = await locals?.auth?.validate() || {};
+	const { sessionId, user } = (await locals?.auth?.validate()) || {};
 
-  if (!sessionId || !user) {
-    return json({ error: 'Unauthorized' }, { status: 401 });
-  }
+	if (!sessionId || !user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
 
-  const userId = user.id;
-  const { saved_word_id, difficulty } = await request.json();
+	const userId = user.id;
+	const { saved_word_id, difficulty } = await request.json();
 
-  // Check paywall: allow free users up to 5 reviews, then require subscription
-  const [hasActiveSubscription, reviewCount] = await Promise.all([
-    getUserHasActiveSubscription(userId),
-    getUserReviewCount(userId)
-  ]);
+	// Check paywall: allow free users up to 5 reviews, then require subscription
+	const [hasActiveSubscription, reviewCount] = await Promise.all([
+		getUserHasActiveSubscription(userId),
+		getUserReviewCount(userId)
+	]);
 
-  if (!hasActiveSubscription && reviewCount >= 5) {
-    return json({ 
-      error: 'Subscription required',
-      message: 'You\'ve reached the free limit of 5 word reviews. Please subscribe to continue using spaced repetition.',
-      requiresSubscription: true,
-      reviewCount
-    }, { status: 403 });
-  }
+	if (!hasActiveSubscription && reviewCount >= 5) {
+		return json(
+			{
+				error: 'Subscription required',
+				message:
+					"You've reached the free limit of 5 word reviews. Please subscribe to continue using spaced repetition.",
+				requiresSubscription: true,
+				reviewCount
+			},
+			{ status: 403 }
+		);
+	}
 
-  if (!saved_word_id || !difficulty || difficulty < 1 || difficulty > 3) {
-    return json({ error: 'Invalid request. saved_word_id and difficulty (1-3) required.' }, { status: 400 });
-  }
+	if (!saved_word_id || !difficulty || difficulty < 1 || difficulty > 3) {
+		return json(
+			{ error: 'Invalid request. saved_word_id and difficulty (1-3) required.' },
+			{ status: 400 }
+		);
+	}
 
-  try {
-    // Get current saved word data
-    const { data: savedWord, error: fetchError } = await supabase
-      .from('saved_word')
-      .select('*')
-      .eq('id', saved_word_id)
-      .eq('user_id', userId)
-      .single();
+	try {
+		// Get current saved word data
+		const { data: savedWord, error: fetchError } = await supabase
+			.from('saved_word')
+			.select('*')
+			.eq('id', saved_word_id)
+			.eq('user_id', userId)
+			.single();
 
-    if (fetchError || !savedWord) {
-      return json({ error: 'Word not found' }, { status: 404 });
-    }
+		if (fetchError || !savedWord) {
+			return json({ error: 'Word not found' }, { status: 404 });
+		}
 
-    // Calculate next review
-    const reviewResult = calculateNextReview(
-      difficulty as 1 | 2 | 3,
-      savedWord.ease_factor || 2.5,
-      savedWord.interval_days || 0,
-      savedWord.repetitions || 0
-    );
+		// Calculate next review
+		const reviewResult = calculateNextReview(
+			difficulty as 1 | 2 | 3,
+			savedWord.ease_factor || 2.5,
+			savedWord.interval_days || 0,
+			savedWord.repetitions || 0
+		);
 
-    // Update saved_word with new spaced repetition data
-    // Also clear forgotten_in_session flag since word is being reviewed
-    const { error: updateError } = await supabase
-      .from('saved_word')
-      .update({
-        ease_factor: reviewResult.easeFactor,
-        interval_days: reviewResult.intervalDays,
-        repetitions: reviewResult.repetitions,
-        next_review_date: reviewResult.nextReviewDate,
-        last_review_date: Date.now(),
-        is_learning: reviewResult.intervalDays < 30, // Consider mastered if interval > 30 days
-        forgotten_in_session: false // Clear forgotten flag when reviewed
-      })
-      .eq('id', saved_word_id);
+		// Update saved_word with new spaced repetition data
+		// Also clear forgotten_in_session flag since word is being reviewed
+		const { error: updateError } = await supabase
+			.from('saved_word')
+			.update({
+				ease_factor: reviewResult.easeFactor,
+				interval_days: reviewResult.intervalDays,
+				repetitions: reviewResult.repetitions,
+				next_review_date: reviewResult.nextReviewDate,
+				last_review_date: Date.now(),
+				is_learning: reviewResult.intervalDays < 30, // Consider mastered if interval > 30 days
+				forgotten_in_session: false // Clear forgotten flag when reviewed
+			})
+			.eq('id', saved_word_id);
 
-    if (updateError) {
-      console.error('Error updating saved word:', updateError);
-      return json({ error: 'Failed to update word' }, { status: 500 });
-    }
+		if (updateError) {
+			console.error('Error updating saved word:', updateError);
+			return json({ error: 'Failed to update word' }, { status: 500 });
+		}
 
-    // Create review history record
-    const reviewId = uuidv4();
-    const { error: reviewError } = await supabase
-      .from('word_review')
-      .insert({
-        id: reviewId,
-        saved_word_id: saved_word_id,
-        user_id: userId,
-        difficulty: difficulty,
-        ease_factor: reviewResult.easeFactor,
-        interval_days: reviewResult.intervalDays,
-        repetitions: reviewResult.repetitions,
-        reviewed_at: Date.now(),
-        next_review_date: reviewResult.nextReviewDate,
-        created_at: Date.now()
-      });
+		// Create review history record
+		const reviewId = uuidv4();
+		const { error: reviewError } = await supabase.from('word_review').insert({
+			id: reviewId,
+			saved_word_id: saved_word_id,
+			user_id: userId,
+			difficulty: difficulty,
+			ease_factor: reviewResult.easeFactor,
+			interval_days: reviewResult.intervalDays,
+			repetitions: reviewResult.repetitions,
+			reviewed_at: Date.now(),
+			next_review_date: reviewResult.nextReviewDate,
+			created_at: Date.now()
+		});
 
-    if (reviewError) {
-      console.error('Error creating review record:', reviewError);
-      // Don't fail the request if review history fails
-    }
+		if (reviewError) {
+			console.error('Error creating review record:', reviewError);
+			// Don't fail the request if review history fails
+		}
 
-    // Track activity (non-blocking)
-    trackActivitySimple(userId, 'review', 1).catch(err => {
-      console.error('Error tracking review activity:', err);
-    });
+		// Track activity (non-blocking)
+		trackActivitySimple(userId, 'review', 1).catch((err) => {
+			console.error('Error tracking review activity:', err);
+		});
 
-    return json({
-      success: true,
-      nextReviewDate: reviewResult.nextReviewDate,
-      intervalDays: reviewResult.intervalDays,
-      repetitions: reviewResult.repetitions
-    });
-  } catch (error) {
-    console.error('Error in review-word endpoint:', error);
-    return json({ error: 'Internal server error' }, { status: 500 });
-  }
+		const posthog = getPostHogClient();
+		posthog.capture({
+			distinctId: userId,
+			event: 'word_reviewed',
+			properties: {
+				difficulty,
+				interval_days: reviewResult.intervalDays,
+				repetitions: reviewResult.repetitions
+			}
+		});
+		posthog.flush().catch(() => {});
+
+		return json({
+			success: true,
+			nextReviewDate: reviewResult.nextReviewDate,
+			intervalDays: reviewResult.intervalDays,
+			repetitions: reviewResult.repetitions
+		});
+	} catch (error) {
+		console.error('Error in review-word endpoint:', error);
+		return json({ error: 'Internal server error' }, { status: 500 });
+	}
 };
-

--- a/src/routes/api/save-word/+server.ts
+++ b/src/routes/api/save-word/+server.ts
@@ -3,90 +3,97 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { supabase } from '$lib/supabaseClient';
 import { trackActivitySimple } from '$lib/helpers/track-activity';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-  const data = await request.json();
-	const { sessionId, user } = await locals?.auth?.validate() || {};
+	const data = await request.json();
+	const { sessionId, user } = (await locals?.auth?.validate()) || {};
 
-  if (!sessionId) {
-    return json({ message: 'You must have an account do that' });
-  }
+	if (!sessionId) {
+		return json({ message: 'You must have an account do that' });
+	}
 
-  const userId = user.id;
-  const savedWordId = uuidv4();
-  const arabicWord = data.activeWordObj.arabic ?? '';
-  const englishWord = data.activeWordObj.english ?? '';
-  const transliteratedWord = data.activeWordObj.transliterated ?? '';
-  const dialect = data.activeWordObj.dialect; // Optional dialect
+	const userId = user.id;
+	const savedWordId = uuidv4();
+	const arabicWord = data.activeWordObj.arabic ?? '';
+	const englishWord = data.activeWordObj.english ?? '';
+	const transliteratedWord = data.activeWordObj.transliterated ?? '';
+	const dialect = data.activeWordObj.dialect; // Optional dialect
 
-  // Check if word already exists in saved_word
-  const { data: wordExists, error: checkError } = await supabase
-    .from('saved_word')
-    .select('*')
-    .eq('arabic_word', arabicWord)
-    .eq('user_id', userId || '');
+	// Check if word already exists in saved_word
+	const { data: wordExists, error: checkError } = await supabase
+		.from('saved_word')
+		.select('*')
+		.eq('arabic_word', arabicWord)
+		.eq('user_id', userId || '');
 
-  if (wordExists?.[0]?.id) {
-    return json({ message: 'You have already saved this' });
-  }
+	if (wordExists?.[0]?.id) {
+		return json({ message: 'You have already saved this' });
+	}
 
-  try {
-    // Try to find the word in the word table to link via word_id
-    let wordId: string | null = null;
-    if (arabicWord) {
-      let wordQuery = supabase
-        .from('word')
-        .select('id')
-        .eq('arabic_word', arabicWord)
-        .limit(1);
-      
-      // If dialect is provided, filter by it
-      if (dialect) {
-        wordQuery = wordQuery.eq('dialect', dialect);
-      }
-      
-      const { data: wordData, error: wordError } = await wordQuery.maybeSingle();
-      if (wordData && !wordError) {
-        wordId = wordData.id;
-      }
-    }
+	try {
+		// Try to find the word in the word table to link via word_id
+		let wordId: string | null = null;
+		if (arabicWord) {
+			let wordQuery = supabase.from('word').select('id').eq('arabic_word', arabicWord).limit(1);
 
-    // Insert into saved_word with spaced repetition fields initialized
-    const now = Date.now();
-    const { data: insertData, error: insertError } = await supabase
-      .from('saved_word')
-      .insert([{
-        id: savedWordId,
-        user_id: userId ?? '',
-        word_id: wordId, // Link to word table if found
-        arabic_word: arabicWord,
-        english_word: englishWord,
-        transliterated_word: transliteratedWord,
-        dialect: dialect || 'egyptian-arabic', // Store dialect directly
-        ease_factor: 2.5, // Default ease factor
-        interval_days: 0, // Start at 0 days
-        repetitions: 0, // No repetitions yet
-        next_review_date: null, // Will be set on first review
-        last_review_date: null,
-        is_learning: true, // New words start as learning
-        mastery_level: 0, // 0 = new
-        created_at: now
-      }])
-      .select();
+			// If dialect is provided, filter by it
+			if (dialect) {
+				wordQuery = wordQuery.eq('dialect', dialect);
+			}
 
-    if (insertError) {
-      console.error('Error saving word:', insertError);
-      return json({ message: 'Something went wrong' });
-    }
+			const { data: wordData, error: wordError } = await wordQuery.maybeSingle();
+			if (wordData && !wordError) {
+				wordId = wordData.id;
+			}
+		}
 
-    // Track activity (non-blocking)
-    trackActivitySimple(userId, 'saved_word', 1).catch(err => {
-      console.error('Error tracking saved word activity:', err);
-    });
+		// Insert into saved_word with spaced repetition fields initialized
+		const now = Date.now();
+		const { data: insertData, error: insertError } = await supabase
+			.from('saved_word')
+			.insert([
+				{
+					id: savedWordId,
+					user_id: userId ?? '',
+					word_id: wordId, // Link to word table if found
+					arabic_word: arabicWord,
+					english_word: englishWord,
+					transliterated_word: transliteratedWord,
+					dialect: dialect || 'egyptian-arabic', // Store dialect directly
+					ease_factor: 2.5, // Default ease factor
+					interval_days: 0, // Start at 0 days
+					repetitions: 0, // No repetitions yet
+					next_review_date: null, // Will be set on first review
+					last_review_date: null,
+					is_learning: true, // New words start as learning
+					mastery_level: 0, // 0 = new
+					created_at: now
+				}
+			])
+			.select();
 
-    return json({ message: 'Saved' });
-  } catch (e) {
-    console.error('Exception saving word:', e);
-    return json({ message: 'Something went wrong' }, { status: 500 });
-  }
-}
+		if (insertError) {
+			console.error('Error saving word:', insertError);
+			return json({ message: 'Something went wrong' });
+		}
+
+		// Track activity (non-blocking)
+		trackActivitySimple(userId, 'saved_word', 1).catch((err) => {
+			console.error('Error tracking saved word activity:', err);
+		});
+
+		const posthog = getPostHogClient();
+		posthog.capture({
+			distinctId: userId,
+			event: 'word_saved',
+			properties: { dialect: dialect || 'egyptian-arabic' }
+		});
+		posthog.flush().catch(() => {});
+
+		return json({ message: 'Saved' });
+	} catch (e) {
+		console.error('Exception saving word:', e);
+		return json({ message: 'Something went wrong' }, { status: 500 });
+	}
+};

--- a/src/routes/api/structured-lessons/start/+server.ts
+++ b/src/routes/api/structured-lessons/start/+server.ts
@@ -1,12 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { v4 as uuidv4 } from 'uuid';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	const { supabase, safeGetSession } = locals;
-	
+
 	const { session, user } = await safeGetSession();
-	
+
 	if (!session || !user) {
 		return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 	}
@@ -49,20 +50,18 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			}
 		} else {
 			// Create new record
-			const { error: insertError } = await supabase
-				.from('structured_lesson_progress')
-				.insert({
-					id: uuidv4(),
-					user_id: user.id,
-					topic_id: topicId,
-					dialect: dialect,
-					status: 'in_progress',
-					started_at: now,
-					last_accessed_at: now,
-					progress_percentage: 0,
-					created_at: now,
-					updated_at: now
-				});
+			const { error: insertError } = await supabase.from('structured_lesson_progress').insert({
+				id: uuidv4(),
+				user_id: user.id,
+				topic_id: topicId,
+				dialect: dialect,
+				status: 'in_progress',
+				started_at: now,
+				last_accessed_at: now,
+				progress_percentage: 0,
+				created_at: now,
+				updated_at: now
+			});
 
 			if (insertError) {
 				console.error('Error creating lesson progress:', insertError);
@@ -70,10 +69,17 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			}
 		}
 
+		const posthog = getPostHogClient();
+		posthog.capture({
+			distinctId: user.id,
+			event: 'lesson_started',
+			properties: { topic_id: topicId, dialect }
+		});
+		await posthog.flush();
+
 		return json({ success: true });
 	} catch (error) {
 		console.error('Error in start lesson endpoint:', error);
 		return json({ success: false, error: 'Internal server error' }, { status: 500 });
 	}
 };
-

--- a/src/routes/api/tutor-save-session/+server.ts
+++ b/src/routes/api/tutor-save-session/+server.ts
@@ -1,133 +1,127 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { supabase } from '$lib/supabaseClient';
-import { 
-  updateConversationSummary,
-  upsertLearningInsight
-} from '$lib/utils/tutor-memory';
+import { getPostHogClient } from '$lib/server/posthog';
+import { updateConversationSummary, upsertLearningInsight } from '$lib/utils/tutor-memory';
 
 interface VocabularyWord {
-  arabic: string;
-  english: string;
-  transliteration: string;
+	arabic: string;
+	english: string;
+	transliteration: string;
 }
 
 interface Insight {
-  type: 'weakness' | 'strength' | 'topic_interest' | 'vocabulary_gap';
-  content: string;
+	type: 'weakness' | 'strength' | 'topic_interest' | 'vocabulary_gap';
+	content: string;
 }
 
 function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+	return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 }
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-  try {
-    // @ts-expect-error - safeGetSession exists on locals at runtime
-    const { user } = await locals.safeGetSession();
-    
-    if (!user) {
-      return error(401, { message: 'Not authenticated' });
-    }
+	try {
+		// @ts-expect-error - safeGetSession exists on locals at runtime
+		const { user } = await locals.safeGetSession();
 
-    const { 
-      conversationId, 
-      dialect,
-      summary, 
-      topics, 
-      arabicWords,
-      selectedWords,
-      insights 
-    } = await request.json();
+		if (!user) {
+			return error(401, { message: 'Not authenticated' });
+		}
 
-    if (!conversationId) {
-      return error(400, { message: 'conversationId is required' });
-    }
+		const { conversationId, dialect, summary, topics, arabicWords, selectedWords, insights } =
+			await request.json();
 
-    // 1. Save conversation summary to database
-    await updateConversationSummary(
-      conversationId,
-      summary,
-      topics,
-      arabicWords || []
-    );
+		if (!conversationId) {
+			return error(400, { message: 'conversationId is required' });
+		}
 
-    // 2. Save learning insights
-    if (insights && Array.isArray(insights)) {
-      for (const insight of insights as Insight[]) {
-        await upsertLearningInsight(
-          user.id,
-          dialect,
-          insight.type,
-          insight.content,
-          0.5
-        );
-      }
-    }
+		// 1. Save conversation summary to database
+		await updateConversationSummary(conversationId, summary, topics, arabicWords || []);
 
-    // 3. Save selected words to user's saved_word table for review
-    let savedWordsCount = 0;
-    if (selectedWords && Array.isArray(selectedWords) && selectedWords.length > 0) {
-      const wordsToInsert = (selectedWords as VocabularyWord[]).map(word => ({
-        id: generateId(),
-        user_id: user.id,
-        arabic_word: word.arabic,
-        english_word: word.english,
-        transliterated_word: word.transliteration,
-        dialect: dialect,
-        created_at: Date.now(),
-        ease_factor: 2.5,
-        interval_days: 0,
-        repetitions: 0,
-        is_learning: true,
-        mastery_level: 0,
-        forgotten_in_session: false
-      }));
+		// 2. Save learning insights
+		if (insights && Array.isArray(insights)) {
+			for (const insight of insights as Insight[]) {
+				await upsertLearningInsight(user.id, dialect, insight.type, insight.content, 0.5);
+			}
+		}
 
-      // Check for duplicates first - don't insert words that already exist
-      const { data: existingWords } = await supabase
-        .from('saved_word')
-        .select('arabic_word')
-        .eq('user_id', user.id)
-        .eq('dialect', dialect)
-        .in('arabic_word', wordsToInsert.map(w => w.arabic_word));
+		// 3. Save selected words to user's saved_word table for review
+		let savedWordsCount = 0;
+		if (selectedWords && Array.isArray(selectedWords) && selectedWords.length > 0) {
+			const wordsToInsert = (selectedWords as VocabularyWord[]).map((word) => ({
+				id: generateId(),
+				user_id: user.id,
+				arabic_word: word.arabic,
+				english_word: word.english,
+				transliterated_word: word.transliteration,
+				dialect: dialect,
+				created_at: Date.now(),
+				ease_factor: 2.5,
+				interval_days: 0,
+				repetitions: 0,
+				is_learning: true,
+				mastery_level: 0,
+				forgotten_in_session: false
+			}));
 
-      const existingArabicWords = new Set(existingWords?.map(w => w.arabic_word) || []);
-      const newWords = wordsToInsert.filter(w => !existingArabicWords.has(w.arabic_word));
+			// Check for duplicates first - don't insert words that already exist
+			const { data: existingWords } = await supabase
+				.from('saved_word')
+				.select('arabic_word')
+				.eq('user_id', user.id)
+				.eq('dialect', dialect)
+				.in(
+					'arabic_word',
+					wordsToInsert.map((w) => w.arabic_word)
+				);
 
-      if (newWords.length > 0) {
-        const { error: insertError } = await supabase
-          .from('saved_word')
-          .insert(newWords);
+			const existingArabicWords = new Set(existingWords?.map((w) => w.arabic_word) || []);
+			const newWords = wordsToInsert.filter((w) => !existingArabicWords.has(w.arabic_word));
 
-        if (insertError) {
-          console.error('Error saving words:', insertError);
-        } else {
-          savedWordsCount = newWords.length;
-          
-          // Update user's total saved words count
-          await supabase
-            .from('user')
-            .update({ 
-              total_saved_words: (user.total_saved_words || 0) + newWords.length,
-              saved_words_this_week: (user.saved_words_this_week || 0) + newWords.length
-            })
-            .eq('id', user.id);
-        }
-      }
-    }
+			if (newWords.length > 0) {
+				const { error: insertError } = await supabase.from('saved_word').insert(newWords);
 
-    return json({
-      success: true,
-      savedWordsCount,
-      message: savedWordsCount > 0 
-        ? `Session saved! ${savedWordsCount} new word${savedWordsCount !== 1 ? 's' : ''} added to your review deck.`
-        : 'Session saved!'
-    });
+				if (insertError) {
+					console.error('Error saving words:', insertError);
+				} else {
+					savedWordsCount = newWords.length;
 
-  } catch (e) {
-    console.error('Error saving tutor session:', e);
-    return error(500, { message: 'Failed to save session' });
-  }
+					// Update user's total saved words count
+					await supabase
+						.from('user')
+						.update({
+							total_saved_words: (user.total_saved_words || 0) + newWords.length,
+							saved_words_this_week: (user.saved_words_this_week || 0) + newWords.length
+						})
+						.eq('id', user.id);
+				}
+			}
+		}
+
+		const posthog = getPostHogClient();
+		posthog.capture({
+			distinctId: user.id,
+			event: 'tutor_session_saved',
+			properties: {
+				dialect,
+				saved_words_count: savedWordsCount,
+				topics: topics || []
+			}
+		});
+		posthog.flush().catch(() => {});
+
+		return json({
+			success: true,
+			savedWordsCount,
+			message:
+				savedWordsCount > 0
+					? `Session saved! ${savedWordsCount} new word${
+							savedWordsCount !== 1 ? 's' : ''
+						} added to your review deck.`
+					: 'Session saved!'
+		});
+	} catch (e) {
+		console.error('Error saving tutor session:', e);
+		return error(500, { message: 'Failed to save session' });
+	}
 };
-

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -1,59 +1,73 @@
-import { redirect } from '@sveltejs/kit'
-import type { RequestHandler } from './$types'
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const POST: RequestHandler = async ({ locals, cookies, request, url }) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const supabase = (locals as any).supabase;
-  console.log('🔍 [logout] POST request received');
-  console.log('🔍 [logout] URL:', url.pathname);
-  console.log('🔍 [logout] Referer:', request.headers.get('referer'));
-  console.log('🔍 [logout] User-Agent:', request.headers.get('user-agent'));
-  
-  try {
-    console.log('🔍 [logout] Attempting to sign out from Supabase...');
-    // Sign out from Supabase (this clears the auth cookies)
-    const { error } = await supabase.auth.signOut()
-    
-    if (error) {
-      console.error('❌ [logout] Supabase signout error:', error);
-      console.error('❌ [logout] Error details:', JSON.stringify(error, null, 2));
-    } else {
-      console.log('✅ [logout] Supabase signout successful');
-    }
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const supabase = (locals as any).supabase;
+	const { user } = await locals.safeGetSession();
+	console.log('🔍 [logout] POST request received');
+	console.log('🔍 [logout] URL:', url.pathname);
+	console.log('🔍 [logout] Referer:', request.headers.get('referer'));
+	console.log('🔍 [logout] User-Agent:', request.headers.get('user-agent'));
 
-    console.log('🔍 [logout] Clearing auth-related cookies...');
-    // Additional cleanup: manually clear any auth-related cookies
-    const cookieOptions = { 
-      path: '/', 
-      maxAge: 0 // This deletes the cookie
-    }
-    
-    // Clear common Supabase auth cookies
-    cookies.delete('sb-access-token', cookieOptions)
-    cookies.delete('sb-refresh-token', cookieOptions)
-    console.log('✅ [logout] Cleared sb-access-token and sb-refresh-token');
-    
-    // Clear any cookies that match the pattern sb-{project-id}-auth-token
-    const allCookies = cookies.getAll()
-    console.log('🔍 [logout] All cookies before cleanup:', allCookies.map(c => c.name));
-    
-    let deletedCount = 0;
-    allCookies.forEach(cookie => {
-      if (cookie.name.startsWith('sb-') && cookie.name.includes('-auth-token')) {
-        cookies.delete(cookie.name, cookieOptions)
-        deletedCount++;
-        console.log(`✅ [logout] Deleted cookie: ${cookie.name}`);
-      }
-    })
-    console.log(`✅ [logout] Deleted ${deletedCount} Supabase auth cookies`);
-    
-    console.log('✅ [logout] Logout process completed successfully');
-  } catch (error) {
-    console.error('❌ [logout] Error during logout:', error);
-    console.error('❌ [logout] Error stack:', error instanceof Error ? error.stack : 'No stack trace');
-  }
-  
-  console.log('🔍 [logout] Redirecting to home page...');
-  // Always redirect to home, even if there were errors
-  redirect(303, '/')
-}
+	try {
+		console.log('🔍 [logout] Attempting to sign out from Supabase...');
+		// Sign out from Supabase (this clears the auth cookies)
+		const { error } = await supabase.auth.signOut();
+
+		if (error) {
+			console.error('❌ [logout] Supabase signout error:', error);
+			console.error('❌ [logout] Error details:', JSON.stringify(error, null, 2));
+		} else {
+			console.log('✅ [logout] Supabase signout successful');
+		}
+
+		console.log('🔍 [logout] Clearing auth-related cookies...');
+		// Additional cleanup: manually clear any auth-related cookies
+		const cookieOptions = {
+			path: '/',
+			maxAge: 0 // This deletes the cookie
+		};
+
+		// Clear common Supabase auth cookies
+		cookies.delete('sb-access-token', cookieOptions);
+		cookies.delete('sb-refresh-token', cookieOptions);
+		console.log('✅ [logout] Cleared sb-access-token and sb-refresh-token');
+
+		// Clear any cookies that match the pattern sb-{project-id}-auth-token
+		const allCookies = cookies.getAll();
+		console.log(
+			'🔍 [logout] All cookies before cleanup:',
+			allCookies.map((c) => c.name)
+		);
+
+		let deletedCount = 0;
+		allCookies.forEach((cookie) => {
+			if (cookie.name.startsWith('sb-') && cookie.name.includes('-auth-token')) {
+				cookies.delete(cookie.name, cookieOptions);
+				deletedCount++;
+				console.log(`✅ [logout] Deleted cookie: ${cookie.name}`);
+			}
+		});
+		console.log(`✅ [logout] Deleted ${deletedCount} Supabase auth cookies`);
+
+		if (user) {
+			const posthog = getPostHogClient();
+			posthog.capture({ distinctId: user.id, event: 'user_logged_out' });
+			await posthog.flush();
+		}
+
+		console.log('✅ [logout] Logout process completed successfully');
+	} catch (error) {
+		console.error('❌ [logout] Error during logout:', error);
+		console.error(
+			'❌ [logout] Error stack:',
+			error instanceof Error ? error.stack : 'No stack trace'
+		);
+	}
+
+	console.log('🔍 [logout] Redirecting to home page...');
+	// Always redirect to home, even if there were errors
+	redirect(303, '/');
+};

--- a/src/routes/generated_story/[id]/+page.svelte
+++ b/src/routes/generated_story/[id]/+page.svelte
@@ -32,6 +32,7 @@
   import StoryAudioButton from '$lib/components/StoryAudioButton.svelte';
   import InlineAudioButton from '$lib/components/InlineAudioButton.svelte';
   import { goto } from '$app/navigation';
+  import { trackEvent } from '$lib/analytics';
 
   interface Props {
     data: PageData;
@@ -61,6 +62,12 @@
   }
 
   onMount(() => {
+    trackEvent('story_viewed', {
+      story_id: (data as any).storyData?.id,
+      dialect: storyDialect,
+      difficulty: (data as any).storyData?.difficulty,
+      sentence_count: story?.sentences?.length ?? 0
+    });
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   });
@@ -218,6 +225,12 @@
 			const result = await res.json();
 			if (result.success) {
 				storyXpAwarded = true;
+				trackEvent('story_completed', {
+					story_id: storyId,
+					xp_awarded: result.xpAwarded,
+					leveled_up: result.leveledUp,
+					is_daily_challenge: !!challengeId
+				});
 				let totalXpAwarded = result.xpAwarded;
 				let finalTotalXp = result.newTotalXp;
 				let finalLevel = result.newLevel;
@@ -510,6 +523,7 @@
             <input
               type="checkbox"
               bind:checked={showEnglish}
+              onchange={() => trackEvent('story_display_toggled', { setting_name: 'english', enabled: showEnglish })}
               class="sr-only peer"
             />
             <div class="w-10 h-5 bg-tile-600 rounded-full peer peer-checked:bg-blue-500 transition-colors"></div>
@@ -524,6 +538,7 @@
             <input
               type="checkbox"
               bind:checked={showTransliteration}
+              onchange={() => trackEvent('story_display_toggled', { setting_name: 'transliteration', enabled: showTransliteration })}
               class="sr-only peer"
             />
             <div class="w-10 h-5 bg-tile-600 rounded-full peer peer-checked:bg-blue-500 transition-colors"></div>
@@ -539,6 +554,7 @@
               <input
                 type="checkbox"
                 bind:checked={showTashkeel}
+                onchange={() => trackEvent('story_display_toggled', { setting_name: 'tashkeel', enabled: showTashkeel })}
                 class="sr-only peer"
               />
               <div class="w-10 h-5 bg-tile-600 rounded-full peer peer-checked:bg-blue-500 transition-colors"></div>
@@ -917,6 +933,7 @@
                     showHint: questionState.showHint
                   };
                   quizStates = { ...quizStates };
+                  trackEvent('story_quiz_answer_submitted', { story_id: (data as any).storyData?.id, question_index: qIndex, is_correct: isCorrectOption });
                 }}
                 disabled={questionState.isAnswered}
                 class={cn(
@@ -981,6 +998,7 @@
                     showHint: !questionState.showHint
                   };
                   quizStates = { ...quizStates };
+                  if (quizStates[qIndex].showHint) trackEvent('story_quiz_hint_viewed', { story_id: (data as any).storyData?.id, question_index: qIndex });
                 }}
                 class="flex items-center gap-2 text-sm text-text-200 hover:text-text-300 transition-colors"
               >

--- a/src/routes/lessons/+page.svelte
+++ b/src/routes/lessons/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import PaywallModal from '$lib/components/PaywallModal.svelte';
 	import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
+	import { trackEvent } from '$lib/analytics';
 
 	let { data } = $props();
 	let isModalOpen = $state(false);
@@ -183,7 +184,7 @@
 
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 				<!-- Structured Lessons -->
-				<a href="/lessons/structured" class="group block rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300">
+				<a href="/lessons/structured" onclick={() => trackEvent('lessons_path_selected', { path: 'structured' })} class="group block rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300">
 					<article class="flex flex-col h-full bg-tile-400 border border-tile-500 rounded-xl p-6 shadow-sm hover:shadow-lg transition-all duration-200 hover:-translate-y-1 motion-reduce:hover:translate-y-0">
 						<div class="w-14 h-14 bg-tile-300 border border-tile-500 rounded-xl flex items-center justify-center mb-4">
 							<span class="text-3xl">📚</span>
@@ -205,7 +206,7 @@
 				</a>
 
 				<!-- Customizable Lessons (purple accent) -->
-				<a href="/lessons/custom" class="group block rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300">
+				<a href="/lessons/custom" onclick={() => trackEvent('lessons_path_selected', { path: 'custom' })} class="group block rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300">
 					<article class="flex flex-col h-full bg-tile-400 border border-purple-500/50 rounded-xl p-6 shadow-sm hover:shadow-lg transition-all duration-200 hover:-translate-y-1 motion-reduce:hover:translate-y-0">
 						<div class="w-14 h-14 bg-purple-500/15 border border-purple-500/40 rounded-xl flex items-center justify-center mb-4">
 							<span class="text-3xl">🎨</span>

--- a/src/routes/lessons/[id]/+page.svelte
+++ b/src/routes/lessons/[id]/+page.svelte
@@ -10,6 +10,7 @@
 	import LessonPlayer from '$lib/components/LessonPlayer.svelte';
 	import type { Dialect } from '$lib/types/index';
 	import type { GeneratedLesson } from '$lib/schemas/curriculum-schema';
+	import { trackEvent } from '$lib/analytics';
 
 	let { data } = $props<{ data: PageData }>();
 	
@@ -42,6 +43,7 @@
 	});
 
 	function openPronunciationTest(text: string, transliteration?: string, english?: string) {
+		trackEvent('lessons_pronunciation_test_opened', { lesson_id: lesson?.id, arabic_text: text });
 		pronunciationText = text;
 		pronunciationTransliteration = transliteration || '';
 		pronunciationEnglish = english || '';
@@ -134,6 +136,7 @@
 	// Navigation functions
 	function goToSubLesson(index: number) {
 		if (lessonBody?.subLessons && index >= 0 && index < lessonBody.subLessons.length) {
+			trackEvent('lessons_sub_lesson_selected', { lesson_id: lesson?.id, sub_lesson_index: index });
 			currentSubLessonIndex = index;
 			// Scroll to top of sub-lesson area
 			const subLessonElement = document.getElementById(`sub-lesson-${index}`);
@@ -491,6 +494,7 @@
 									<button
 										type="button"
 										onclick={() => {
+											trackEvent('lessons_continue_to_review_clicked', { lesson_id: lesson?.id });
 											const reviewSection = document.getElementById('review-section');
 											if (reviewSection) {
 												reviewSection.scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/src/routes/lessons/custom/+page.svelte
+++ b/src/routes/lessons/custom/+page.svelte
@@ -2,6 +2,7 @@
 	import PaywallModal from '$lib/components/PaywallModal.svelte';
 	import AuthModal from '$lib/components/AuthModal.svelte';
 	import CreateLessonModal from '$lib/components/dialect-shared/lesson/components/CreateLessonModal.svelte';
+	import { trackEvent } from '$lib/analytics';
 
 	let { data } = $props();
 	let isModalOpen = $state(false);
@@ -12,9 +13,11 @@
 		// Check authentication before navigating
 		if (!data.session || !data.user) {
 			e.preventDefault();
+			trackEvent('lessons_auth_required', { lesson_id: lessonId });
 			isAuthModalOpen = true;
 			return false;
 		}
+		trackEvent('lessons_custom_accessed', { lesson_id: lessonId, view: activeView });
 		return true;
 	}
 
@@ -232,14 +235,14 @@
 			<div class="flex p-1 bg-tile-400 border border-tile-500 rounded-lg w-fit mb-4">
 				<button
 					type="button"
-					onclick={() => activeView = 'all'}
+					onclick={() => { activeView = 'all'; trackEvent('lessons_custom_view_toggled', { view: 'all', lessons_count: userGeneratedLessons.length }); }}
 					class="px-4 py-2 text-sm rounded-md transition-all duration-200 font-semibold {activeView === 'all' ? 'bg-tile-600 text-text-300 shadow-sm' : 'text-text-200 hover:text-text-300'}"
 				>
 					All Lessons
 				</button>
 				<button
 					type="button"
-					onclick={() => activeView = 'mine'}
+					onclick={() => { activeView = 'mine'; trackEvent('lessons_custom_view_toggled', { view: 'mine', lessons_count: privateLessons.length }); }}
 					class="px-4 py-2 text-sm rounded-md transition-all duration-200 font-semibold {activeView === 'mine' ? 'bg-tile-600 text-text-300 shadow-sm' : 'text-text-200 hover:text-text-300'}"
 				>
 					🔒 My Private Lessons
@@ -259,6 +262,7 @@
 						type="text"
 						placeholder="Search lessons by title or description..."
 						bind:value={searchQuery}
+						onchange={() => searchQuery.trim() && trackEvent('lessons_custom_searched', { query: searchQuery, results_count: filteredAndSortedLessons.length })}
 						class="w-full pl-10 pr-4 py-2.5 text-sm border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600"
 					/>
 					<div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -274,6 +278,7 @@
 					<select
 						id="dialect-filter-lessons"
 						bind:value={filterDialect}
+						onchange={() => trackEvent('lessons_custom_filter_changed', { filter_type: 'dialect', value: filterDialect, results_count: filteredAndSortedLessons.length })}
 						class="w-full px-3 py-2 text-sm border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600 cursor-pointer"
 					>
 						{#each filterDialectOptions as option}
@@ -288,6 +293,7 @@
 					<select
 						id="level-filter-lessons"
 						bind:value={filterLevel}
+						onchange={() => trackEvent('lessons_custom_filter_changed', { filter_type: 'level', value: filterLevel, results_count: filteredAndSortedLessons.length })}
 						class="w-full px-3 py-2 text-sm border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600 cursor-pointer"
 					>
 						{#each levelOptions as option}
@@ -302,6 +308,7 @@
 					<select
 						id="sort-filter-lessons"
 						bind:value={sortBy}
+						onchange={() => trackEvent('lessons_custom_sorted', { sort_by: sortBy })}
 						class="w-full px-3 py-2 text-sm border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600 cursor-pointer"
 					>
 						<option value="newest">Newest First</option>

--- a/src/routes/lessons/structured/[dialect]/+page.svelte
+++ b/src/routes/lessons/structured/[dialect]/+page.svelte
@@ -6,6 +6,7 @@
     import type { GeneratedLesson } from '$lib/schemas/curriculum-schema';
 	import { invalidateAll } from '$app/navigation';
 	import { onMount } from 'svelte';
+	import { trackEvent } from '$lib/analytics';
 
 	let { data } = $props();
 	let isModalOpen = $state(false);
@@ -141,6 +142,7 @@
     async function handleLessonClick(lessonNode: any) {
         // Check authentication first
         if (!data.user || !data.session) {
+            trackEvent('lessons_auth_required', { lesson_id: lessonNode.id, dialect: lessonNode.dialect });
             isAuthModalOpen = true;
             return;
         }
@@ -148,6 +150,7 @@
         if (lessonNode.status === 'locked') {
             // Check if it's paywalled
             if (lessonNode.isPaywalled) {
+                trackEvent('lessons_paywall_triggered', { lesson_id: lessonNode.id, dialect: lessonNode.dialect });
                 isModalOpen = true;
                 return;
             }
@@ -164,6 +167,12 @@
         }
         
         try {
+            trackEvent('lessons_lesson_opened', {
+                lesson_id: lessonNode.id,
+                dialect: lessonNode.dialect,
+                lesson_title: lessonNode.title
+            });
+
             // Mark lesson as started if user is logged in
             if (data.user) {
                 try {
@@ -229,6 +238,10 @@
             await invalidateAll();
         }}
         onLessonComplete={async (nextLessonId) => {
+            trackEvent('lessons_lesson_completed', {
+                lesson_id: activeLesson?.topicId,
+                dialect: activeLesson?.dialect
+            });
             // Close the lesson player first (completion already marked in LessonPlayer)
             activeLesson = null;
             

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,50 +1,61 @@
-import { redirect } from '@sveltejs/kit'
-import type { Actions } from './$types'
+import { redirect } from '@sveltejs/kit';
+import type { Actions } from './$types';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const load = async ({ locals: { safeGetSession } }) => {
-  const { session } = await safeGetSession()
+	const { session } = await safeGetSession();
 
-  // If already logged in, redirect to home
-  if (session) {
-    redirect(303, '/')
-  }
+	// If already logged in, redirect to home
+	if (session) {
+		redirect(303, '/');
+	}
 
-  return {}
-}
+	return {};
+};
 
 export const actions: Actions = {
-  login: async ({ request, locals: { supabase } }) => {
-    const formData = await request.formData()
-    const email = formData.get('email') as string
-    const password = formData.get('password') as string
+	login: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const email = formData.get('email') as string;
+		const password = formData.get('password') as string;
 
-    const { data, error } = await supabase.auth.signInWithPassword({ email, password })
+		const { data, error } = await supabase.auth.signInWithPassword({ email, password });
 
-    if (error) {
-      return {
-        error: error.message
-      }
-    }
+		if (error) {
+			return {
+				error: error.message
+			};
+		}
 
-    redirect(303, '/')
-  },
+		if (data.user) {
+			const posthog = getPostHogClient();
+			posthog.capture({
+				distinctId: data.user.id,
+				event: 'user_logged_in',
+				properties: { method: 'email' }
+			});
+			await posthog.flush();
+		}
 
-  resetPassword: async ({ request, locals: { supabase }, url }) => {
-    const formData = await request.formData()
-    const email = formData.get('email') as string
+		redirect(303, '/');
+	},
 
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${url.origin}/auth/reset-password`
-    })
+	resetPassword: async ({ request, locals: { supabase }, url }) => {
+		const formData = await request.formData();
+		const email = formData.get('email') as string;
 
-    if (error) {
-      return {
-        error: error.message
-      }
-    }
+		const { error } = await supabase.auth.resetPasswordForEmail(email, {
+			redirectTo: `${url.origin}/auth/reset-password`
+		});
 
-    return {
-      message: 'Check your email for the password reset link!'
-    }
-  }
-}
+		if (error) {
+			return {
+				error: error.message
+			};
+		}
+
+		return {
+			message: 'Check your email for the password reset link!'
+		};
+	}
+};

--- a/src/routes/pricing/subscribed/+page.server.ts
+++ b/src/routes/pricing/subscribed/+page.server.ts
@@ -1,6 +1,7 @@
 // Modules and libraries
 import { StripeService } from '$lib/services/stripe.service';
 import { redirect } from '@sveltejs/kit';
+import { getPostHogClient } from '$lib/server/posthog';
 
 // Types and variables
 import type { PageServerLoad } from './$types';
@@ -21,13 +22,13 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 
 	const stripeSessionId = url.searchParams.get('session_id');
 	if (stripeSessionId == null) {
-    console.log('❌ No stripe session ID found');
+		console.log('❌ No stripe session ID found');
 		redirect(302, '/pricing/error');
 	}
 
 	const stripeSession = await StripeService.getSession(stripeSessionId);
 	if (stripeSession?.payment_status != 'paid') {
-    console.log('❌ Stripe session payment status is not paid');
+		console.log('❌ Stripe session payment status is not paid');
 		redirect(302, '/pricing/error');
 	}
 
@@ -49,10 +50,10 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 	}
 
 	const subscriberId = String(stripeSession.subscription ?? '');
-	
+
 	// Get the actual subscription details from Stripe instead of hardcoding 30 days
 	let subscriptionEndDate: number;
-	
+
 	if (subscriberId) {
 		try {
 			const subscription = await StripeService.getSubscription(subscriberId);
@@ -87,7 +88,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 			.update({
 				is_subscriber: true,
 				subscriber_id: subscriberId,
-				subscription_end_date: subscriptionEndDate  // Keep as Unix timestamp (bigint)
+				subscription_end_date: subscriptionEndDate // Keep as Unix timestamp (bigint)
 			})
 			.eq('id', userId)
 			.select();
@@ -97,7 +98,20 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 			redirect(302, '/pricing/error');
 		}
 
-    console.log('Result:', updatedUser);
+		console.log('Result:', updatedUser);
+
+		if (userId) {
+			const posthog = getPostHogClient();
+			posthog.capture({
+				distinctId: String(userId),
+				event: 'subscription_started',
+				properties: {
+					subscription_id: subscriberId,
+					subscription_end_date: subscriptionEndDate
+				}
+			});
+			await posthog.flush();
+		}
 
 		return {
 			session: authSession,

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -14,6 +14,7 @@
   import SubscribeButton from '$lib/components/SubscribeButton.svelte';
   import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
   import { fetchUserReviewWords } from '$lib/helpers/fetch-review-words';
+  import { trackEvent } from '$lib/analytics';
 
   interface Props {
     data: PageData;
@@ -47,6 +48,7 @@
   $effect(() => {
     if (sessionComplete && !reviewCycleXpAwarded && reviewedCount > 0) {
       reviewCycleXpAwarded = true;
+      trackEvent('review_session_completed', { total_reviewed: reviewedCount, forgotten_count: forgottenWords.length });
       fetch('/api/award-xp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -152,7 +154,12 @@
 
       savedCount = saveResult.saved;
       generationComplete = true;
-      
+      trackEvent('review_generated_items_saved', {
+        type: generationType,
+        count: saveResult.saved,
+        dialect: selectedDialect
+      });
+
       // Clear selections and close modal
       selectedItems = new Set();
       generatedItems = [];
@@ -365,6 +372,7 @@
 
       reviewedCount++;
       reviewedWordIds.add(word.id);
+      trackEvent('review_word_answered', { word_id: word.id, difficulty, correct: difficulty >= 1, dialect: word.dialect });
       console.log({ difficulty });
       if (difficulty >= 1) {
         fetch('/api/award-xp', {
@@ -448,6 +456,7 @@
   }
 
   async function startNewSession() {
+    trackEvent('review_session_new_started', { previous_reviewed_count: reviewedCount });
     currentIndex = 0;
     reviewedCount = 0;
     reviewedWordIds = new Set();
@@ -497,6 +506,7 @@
           console.error('Error marking word as forgotten:', error);
         }
         
+        trackEvent('review_word_marked_forgotten', { word_id: word.id, dialect: word.dialect });
         forgottenWords.push({ ...word });
         reviewedWordIds.add(word.id);
         reviewedCount++;
@@ -635,6 +645,12 @@
       return;
     }
 
+    trackEvent('review_sentences_generation_started', {
+      dialect: selectedDialect,
+      difficulty: difficultyOption,
+      vocabulary_source: useReviewWordsOnly ? 'review_words' : vocabularyInputMode,
+      learning_topics: selectedLearningTopics
+    });
     isGeneratingSentences = true;
     generateError = null;
     generateSuccess = null;
@@ -818,6 +834,11 @@
   }
 
   async function generateAndSaveWords() {
+    trackEvent('review_words_generation_started', {
+      dialect: selectedDialect,
+      difficulty: difficultyOption,
+      word_types: selectedWordTypes
+    });
     isGeneratingWords = true;
     wordGenerateError = null;
     wordGenerateSuccess = null;
@@ -897,7 +918,7 @@
       <p class="text-text-200 text-lg sm:text-xl leading-snug max-w-2xl mb-4 flex items-center gap-2">
         Practice your saved words with spaced repetition
         <button
-          onclick={() => (showGraduationModal = true)}
+          onclick={() => { showGraduationModal = true; trackEvent('review_graduation_info_opened'); }}
           class="w-5 h-5 rounded-full bg-tile-500 hover:bg-tile-600 text-text-200 hover:text-text-300 text-xs font-bold transition-colors flex items-center justify-center leading-none shrink-0"
           aria-label="How graduation works"
         >?</button>
@@ -1029,7 +1050,7 @@
           <!-- Generate Words -->
           <button
             class="group relative overflow-hidden flex flex-col items-center text-center p-8 rounded-xl border-2 border-tile-600 bg-gradient-to-br from-tile-400/50 to-tile-400/30 shadow-md hover:shadow-2xl hover:-translate-y-2 transition-all duration-300 cursor-pointer"
-            onclick={() => { showGenerateWords = true; showGenerateSentences = false; }}
+            onclick={() => { showGenerateWords = true; showGenerateSentences = false; trackEvent('review_generate_words_opened'); }}
           >
             <!-- Background pattern -->
             <div class="absolute inset-0 opacity-5 group-hover:opacity-10 transition-opacity">
@@ -1046,7 +1067,7 @@
           <!-- Generate Sentences -->
           <button
             class="group relative overflow-hidden flex flex-col items-center text-center p-8 rounded-xl border-2 border-tile-600 bg-gradient-to-br from-tile-400/50 to-tile-400/30 shadow-md hover:shadow-2xl hover:-translate-y-2 transition-all duration-300 cursor-pointer"
-            onclick={() => { showGenerateSentences = true; showGenerateWords = false; }}
+            onclick={() => { showGenerateSentences = true; showGenerateWords = false; trackEvent('review_generate_sentences_opened'); }}
           >
             <!-- Background pattern -->
             <div class="absolute inset-0 opacity-5 group-hover:opacity-10 transition-opacity">

--- a/src/routes/review/all-words/+page.svelte
+++ b/src/routes/review/all-words/+page.svelte
@@ -5,6 +5,7 @@
   import { toast } from 'svelte-sonner';
   import cn from 'classnames';
   import type { Dialect } from '$lib/types';
+  import { trackEvent } from '$lib/analytics';
 
   interface ReviewWord {
     id: string;
@@ -82,6 +83,8 @@
       }
 
       // Remove word from local state
+      const deleted = words.find(w => w.id === wordId);
+      trackEvent('review_word_deleted', { word_id: wordId, status_before_delete: deleted?.status, dialect: deleted?.dialect });
       words = words.filter(w => w.id !== wordId);
       toast.success('Word removed successfully');
     } catch (err) {
@@ -174,6 +177,7 @@
       sortBy = newSortBy;
       sortOrder = 'desc';
     }
+    trackEvent('review_all_words_sorted', { sort_by: sortBy, sort_order: sortOrder });
   }
 
   const statusCounts = $derived.by(() => {
@@ -199,7 +203,7 @@
       <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
         <div class="flex flex-wrap gap-2">
           <button
-            onclick={() => filterStatus = 'all'}
+            onclick={() => { filterStatus = 'all'; trackEvent('review_all_words_filtered', { filter_status: 'all', results_count: filteredWords.length }); }}
             class={cn(
               "px-4 py-2 rounded-lg border transition-colors",
               filterStatus === 'all'
@@ -215,6 +219,7 @@
           type="text"
           placeholder="Search words..."
           bind:value={searchQuery}
+          onchange={() => searchQuery.trim() && trackEvent('review_all_words_searched', { query: searchQuery, results_count: filteredWords.length })}
           class="px-4 py-2 rounded-lg border border-tile-500 bg-tile-300 text-text-100 placeholder-text-200 focus:outline-none focus:ring-2 focus:ring-tile-500"
         />
       </div>

--- a/src/routes/review/components/ReviewCard.svelte
+++ b/src/routes/review/components/ReviewCard.svelte
@@ -8,6 +8,7 @@
   import type { DialectComparisonSchema } from '$lib/utils/gemini-schemas';
   import cn from 'classnames';
   import { filterArabicCharacters } from '$lib/utils/arabic-normalization';
+  import { trackEvent } from '$lib/analytics';
 
   interface ReviewWord {
     id: string;
@@ -61,6 +62,7 @@
   let comparisonError = $state<string | null>(null);
 
   async function compareDialects() {
+    trackEvent('review_card_dialect_comparison_requested', { word_id: word.id, dialect: word.dialect });
     isComparing = true;
     isComparisonModalOpen = true;
     comparisonData = null;
@@ -181,6 +183,7 @@
 
     isFlipping = true;
     showAnswer = !showAnswer;
+    trackEvent('review_card_flipped', { word_id: word.id, revealed: showAnswer });
 
     if (!showAnswer) {
       clearSelection();
@@ -327,7 +330,8 @@
     
     isLoadingDefinition = true;
     isDefinitionModalOpen = true;
-    
+    trackEvent('review_card_definition_requested', { word_id: word.id, selected_text: wordsText, single_word: isSingleWordDefinition });
+
     const wordText = wordsArray.length === 1 ? wordsArray[0] : `the phrase "${wordsText}"`;
     const question = `What does ${wordText} mean in ${dialectName[word.dialect] || word.dialect}? Considering the following sentences:
 		Arabic: "${word.arabic}"
@@ -437,7 +441,7 @@
           </span>
           <button
             type="button"
-            onclick={() => { isStatsModalOpen = true; }}
+            onclick={() => { isStatsModalOpen = true; trackEvent('review_card_stats_opened', { word_id: word.id }); }}
             class="inline-flex items-center px-2 py-0.5 bg-tile-600 text-text-200 rounded-full text-xs hover:bg-tile-500 transition-colors"
             title="View word statistics"
           >
@@ -499,7 +503,7 @@
         {/if}
         <div class="flex flex-col items-center gap-3 mt-4">
           <div class="flex flex-row justify-center gap-2">
-            <Button onClick={() => (showHint = !showHint)} type="button">
+            <Button onClick={() => { showHint = !showHint; trackEvent('review_card_hint_toggled', { word_id: word.id, visible: showHint }); }} type="button">
               {showHint ? 'Hide' : 'Show'} Hint
             </Button>
             <AudioButton text={word.arabic} dialect={word.dialect as Dialect} audioUrl={word.audioUrl}>

--- a/src/routes/review/import/+page.svelte
+++ b/src/routes/review/import/+page.svelte
@@ -6,6 +6,7 @@
   import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
   import { toast } from 'svelte-sonner';
   import { importJobStore, startImportJob } from '$lib/stores/import-job';
+  import { trackEvent } from '$lib/analytics';
 
   interface Props {
     data: PageData;
@@ -98,6 +99,11 @@
   async function importWords() {
     isImporting = true;
     importResult = null;
+    trackEvent('review_import_started', {
+      import_mode: importMode,
+      dialect: importMode === 'csv' ? csvDialect : importMode === 'paste' ? pasteDialect : selectedDialect,
+      category: importMode === 'category' ? selectedCategory : undefined
+    });
 
     try {
       if (importMode === 'csv') {
@@ -169,6 +175,13 @@
           message: result.message
         };
 
+        trackEvent('review_import_completed', {
+          import_mode: 'category',
+          dialect: selectedDialect,
+          imported_count: result.imported || 0,
+          skipped_count: result.skipped || 0
+        });
+
         toast.success(result.message || 'Words imported successfully!', {
           description: result.imported > 0
             ? `${result.imported} word${result.imported !== 1 ? 's' : ''} added to your review deck`
@@ -213,14 +226,14 @@
         <div class="flex rounded-xl border-2 border-tile-600 overflow-hidden">
           <button
             type="button"
-            onclick={() => { importMode = 'csv'; }}
+            onclick={() => { importMode = 'csv'; trackEvent('review_import_mode_selected', { mode: 'csv' }); }}
             class="flex-1 py-3 px-4 text-sm font-medium transition-colors {importMode === 'csv' ? 'bg-tile-600 text-text-300' : 'bg-tile-300/50 text-text-200 hover:bg-tile-400/50'}"
           >
             Upload File
           </button>
           <button
             type="button"
-            onclick={() => { importMode = 'paste'; }}
+            onclick={() => { importMode = 'paste'; trackEvent('review_import_mode_selected', { mode: 'paste' }); }}
             class="flex-1 py-3 px-4 text-sm font-medium transition-colors border-l border-r border-tile-600 {importMode === 'paste' ? 'bg-tile-600 text-text-300' : 'bg-tile-300/50 text-text-200 hover:bg-tile-400/50'}"
           >
             Paste Text

--- a/src/routes/sentences/+page.svelte
+++ b/src/routes/sentences/+page.svelte
@@ -16,6 +16,7 @@
 	import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
 	import { fetchUserReviewWords } from '$lib/helpers/fetch-review-words';
 	import { sentencePractice as session } from '$lib/store/generated-content.svelte';
+	import { trackEvent } from '$lib/analytics';
 
 	let { data } = $props();
 
@@ -87,6 +88,7 @@
 		} else {
 			selectedLearningTopics = [...selectedLearningTopics, topicValue];
 		}
+		trackEvent('sentences_learning_topic_toggled', { topic: topicValue, selected: selectedLearningTopics.includes(topicValue) });
 	}
 
 	async function loadReviewWords() {
@@ -149,6 +151,7 @@
 			}
 			
 			vocabularyFile = file;
+			trackEvent('sentences_vocab_file_uploaded', { file_size_kb: Math.round(file.size / 1024) });
 		} else {
 			vocabularyFile = null;
 		}
@@ -188,6 +191,12 @@
 		isLoading = true;
 		isError = false;
 		errorMessage = '';
+		trackEvent('sentences_generation_started', {
+			difficulty: option,
+			dialect: selectedDialect,
+			vocabulary_source: useReviewWordsOnly ? 'review_words' : vocabularyInputMode,
+			learning_topics: selectedLearningTopics
+		});
 		
 		// Show processing toast
 		const toastId = showSentenceGenerationToast(selectedDialect, 5);
@@ -265,6 +274,7 @@
 
 			// Show success toast
 			showSentenceSuccessToast(toastId, newSentences.length, selectedDialect);
+			trackEvent('sentences_generation_completed', { sentence_count: newSentences.length, dialect: selectedDialect });
 			
 		} catch (error) {
 			console.error('Error generating sentences:', error);
@@ -298,6 +308,7 @@
 		updateSentencesViewed();
 		session.index = session.index + 1;
 		updateUrl('sentence', (session.index+1).toString());
+		trackEvent('sentences_navigated', { direction: 'next', index: session.index });
 	}
 
 	function previous() {
@@ -306,12 +317,14 @@
 		}
 		session.index = session.index - 1;
 		updateUrl('sentence', (session.index+1).toString());
+		trackEvent('sentences_navigated', { direction: 'previous', index: session.index });
 	}
 
 	function setMode(event: any) {
 		const newMode = event.target.value || 'write';
 		mode = newMode;
 		updateUrl('mode', newMode);
+		trackEvent('sentences_practice_mode_selected', { mode: newMode });
 	}
 
 	function setOption(event: any) {
@@ -332,10 +345,12 @@
 	}
 
 	function loadMoreSentences() {
+		trackEvent('sentences_load_more_requested', { dialect: selectedDialect, difficulty: option });
 		generateSentence(option, [...session.sentences]);
 	}
 
 	function resetSentences() {
+		trackEvent('sentences_reset', { dialect: selectedDialect });
 		session.sentences = [];
 		session.index = 0;
 		updateUrl('sentence', '0');

--- a/src/routes/signup/+page.server.ts
+++ b/src/routes/signup/+page.server.ts
@@ -1,77 +1,88 @@
-import { redirect } from '@sveltejs/kit'
-import type { Actions } from './$types'
-import { syncSupabaseUserWithDB } from '$lib/helpers/supabase-auth-helpers'
-import { sendWelcomeEmail } from '$lib/server/email'
-import { ADMIN_ID } from '$env/static/private'
+import { redirect } from '@sveltejs/kit';
+import type { Actions } from './$types';
+import { syncSupabaseUserWithDB } from '$lib/helpers/supabase-auth-helpers';
+import { sendWelcomeEmail } from '$lib/server/email';
+import { ADMIN_ID } from '$env/static/private';
+import { getPostHogClient } from '$lib/server/posthog';
 
 export const load = async ({ locals: { safeGetSession } }) => {
-  const { session } = await safeGetSession()
+	const { session } = await safeGetSession();
 
-  // If already logged in, redirect to home
-  if (session) {
-    redirect(303, '/')
-  }
+	// If already logged in, redirect to home
+	if (session) {
+		redirect(303, '/');
+	}
 
-  return {}
-}
+	return {};
+};
 
 export const actions: Actions = {
-  signup: async ({ request, locals: { supabase } }) => {
-    const formData = await request.formData()
-    const email = formData.get('email') as string
-    const password = formData.get('password') as string
+	signup: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const email = formData.get('email') as string;
+		const password = formData.get('password') as string;
 
-    const { data, error } = await supabase.auth.signUp({ email, password })
-    if (error) {
-      return {
-        error: error.message
-      }
-    }
+		const { data, error } = await supabase.auth.signUp({ email, password });
+		if (error) {
+			return {
+				error: error.message
+			};
+		}
 
-    // If user was created, sync with our database
-    let isNewUser = false
-    if (data.user) {
-      try {
-        const { data: existingUser, error: selectError } = await supabase
-          .from('user')
-          .select('id')
-          .eq('supabase_auth_id', data.user.id)
-          .single()
-        
-        // Check if this is a new user (doesn't exist in our DB yet)
-        // PGRST116 = no rows returned, meaning it's a new user
-        isNewUser = !existingUser && selectError?.code === 'PGRST116'
-        
-        await syncSupabaseUserWithDB(data.user, supabase)
-        
-        // Send welcome email to new users (admin only, non-blocking)
-        // Only send if the new user is an admin (for testing) or if admin triggers it
-        if (isNewUser && email) {
-          // Check if the new user is admin, or if we're in an admin context
-          // For now, only allow if admin ID matches (admin creating their own account)
-          const newUserId = data.user?.id;
-          if (ADMIN_ID && newUserId) {
-            sendWelcomeEmail(email, newUserId).catch(error => {
-              console.error('Failed to send welcome email:', error)
-              // Don't block signup if email fails
-            })
-          }
-        }
-      } catch (syncError) {
-        console.error('Failed to sync user to database:', syncError)
-        // Note: We don't return an error here because the auth was successful
-        // The user sync can be retried on login
-      }
-    }
-    
-    // If it's a new user and they're already authenticated (email confirmation not required),
-    // redirect to home with newSignup flag to trigger onboarding
-    if (isNewUser && data.session) {
-      throw redirect(303, '/?newSignup=true')
-    }
-    
-    return {
-      message: 'Check your email for the confirmation link!'
-    }
-  }
-}
+		// If user was created, sync with our database
+		let isNewUser = false;
+		if (data.user) {
+			try {
+				const { data: existingUser, error: selectError } = await supabase
+					.from('user')
+					.select('id')
+					.eq('supabase_auth_id', data.user.id)
+					.single();
+
+				// Check if this is a new user (doesn't exist in our DB yet)
+				// PGRST116 = no rows returned, meaning it's a new user
+				isNewUser = !existingUser && selectError?.code === 'PGRST116';
+
+				await syncSupabaseUserWithDB(data.user, supabase);
+
+				// Send welcome email to new users (admin only, non-blocking)
+				// Only send if the new user is an admin (for testing) or if admin triggers it
+				if (isNewUser && email) {
+					// Check if the new user is admin, or if we're in an admin context
+					// For now, only allow if admin ID matches (admin creating their own account)
+					const newUserId = data.user?.id;
+					if (ADMIN_ID && newUserId) {
+						sendWelcomeEmail(email, newUserId).catch((error) => {
+							console.error('Failed to send welcome email:', error);
+							// Don't block signup if email fails
+						});
+					}
+				}
+			} catch (syncError) {
+				console.error('Failed to sync user to database:', syncError);
+				// Note: We don't return an error here because the auth was successful
+				// The user sync can be retried on login
+			}
+		}
+
+		if (isNewUser && data.user) {
+			const posthog = getPostHogClient();
+			posthog.capture({
+				distinctId: data.user.id,
+				event: 'user_signed_up',
+				properties: { method: 'email' }
+			});
+			await posthog.flush();
+		}
+
+		// If it's a new user and they're already authenticated (email confirmation not required),
+		// redirect to home with newSignup flag to trigger onboarding
+		if (isNewUser && data.session) {
+			throw redirect(303, '/?newSignup=true');
+		}
+
+		return {
+			message: 'Check your email for the confirmation link!'
+		};
+	}
+};

--- a/src/routes/stories/+page.svelte
+++ b/src/routes/stories/+page.svelte
@@ -8,6 +8,7 @@
 	import { START_HERE_TOPICS, ALL_TOPICS } from '$lib/constants/story-topics';
 	import type { StoryTopic } from '$lib/constants/story-topics';
 	import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
+	import { trackEvent } from '$lib/analytics';
 
 	let { data } = $props();
 
@@ -115,6 +116,7 @@
 	async function loadMoreStories() {
 		if (isLoadingStories || !hasMore || !nextCursor) return;
 		isLoadingStories = true;
+		trackEvent('stories_load_more', { loaded_count: allLoadedStories.length });
 		try {
 			const res = await fetch(`/api/stories?${buildStoryParams({ cursor: nextCursor })}`);
 			const result = await res.json();
@@ -167,6 +169,12 @@
 		generatingTopicName = topic.name;
 		isGeneratingModalOpen = true;
 		generationError = null;
+		trackEvent('stories_generation_started', {
+			topic_id: topic.id,
+			topic_name: topic.name,
+			dialect: data.user?.target_dialect ?? 'egyptian-arabic',
+			source: 'topic_card'
+		});
 		try {
 			const reviewWords = await fetchUserReviewWords(data.user.id, 'due-for-review');
 			const vocabularyWords = reviewWords
@@ -199,6 +207,7 @@
 			if (!res.ok) throw new Error(result.error || 'Failed to generate story');
 
 			const storyId: string = result.storyId;
+			trackEvent('stories_generation_succeeded', { story_id: storyId, topic_id: topic.id, dialect: data.user?.target_dialect ?? 'egyptian-arabic' });
 			topicStoryMap = { ...topicStoryMap, [topic.id]: storyId };
 			// Persist mapping in DB (fire-and-forget — navigation happens immediately)
 			fetch('/api/topic-story', {
@@ -211,6 +220,7 @@
 		} catch (err) {
 			isGeneratingModalOpen = false;
 			generationError = err instanceof Error ? err.message : 'Something went wrong. Please try again.';
+			trackEvent('stories_generation_failed', { topic_id: topic.id, dialect: data.user?.target_dialect ?? 'egyptian-arabic' });
 		} finally {
 			generatingTopicId = null;
 		}
@@ -221,6 +231,7 @@
 	}
 
 	function handleCardClick(topic: StoryTopic) {
+		trackEvent('stories_topic_card_clicked', { topic_id: topic.id, topic_name: topic.name, story_state: getTopicState(topic) });
 		if (!data.user) {
 			goto('/login');
 			return;
@@ -342,6 +353,7 @@
 		<div class="mb-6">
 			<a
 				href={`/generated_story/${data.resumeStory.id}`}
+				onclick={() => trackEvent('stories_story_resumed', { story_id: data.resumeStory?.id })}
 				class="group flex items-center justify-between bg-tile-500 border border-amber-400/50 rounded-xl p-4 sm:p-5 shadow-sm hover:bg-tile-600 hover:shadow-lg transition-all duration-200 hover:-translate-y-1 motion-reduce:hover:translate-y-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300"
 			>
 				<div class="flex flex-col gap-1 min-w-0">
@@ -478,7 +490,7 @@
 				<select
 					id="stories-dialect"
 					bind:value={filterDialect}
-					onchange={() => resetStories()}
+					onchange={() => { trackEvent('stories_filter_applied', { filter_type: 'dialect', value: filterDialect }); resetStories(); }}
 					class="w-full px-3 py-2 text-sm border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600"
 				>
 					<option value="all">All Dialects</option>
@@ -493,7 +505,7 @@
 				<select
 					id="stories-difficulty"
 					bind:value={filterDifficulty}
-					onchange={() => resetStories()}
+					onchange={() => { trackEvent('stories_filter_applied', { filter_type: 'difficulty', value: filterDifficulty }); resetStories(); }}
 					class="w-full px-3 py-2 text-sm border border-tile-500 bg-tile-300 text-text-300 rounded-lg focus:outline-none focus:border-tile-600 focus:ring-1 focus:ring-tile-600"
 				>
 					<option value="all">All Levels</option>
@@ -507,7 +519,7 @@
 			</div>
 			{#if data.user}
 				<button
-					onclick={() => { filterByMe = !filterByMe; resetStories(); }}
+					onclick={() => { filterByMe = !filterByMe; trackEvent('stories_filter_applied', { filter_type: 'by_me', value: filterByMe }); resetStories(); }}
 					class="px-4 py-2 text-sm font-medium rounded-lg border transition-colors
 						{filterByMe
 							? 'bg-tile-600 border-tile-600 text-text-300'
@@ -543,6 +555,7 @@
 					{@const canReadFull = data.hasActiveSubscription}
 					<a
 						href={`/generated_story/${story.id}`}
+						onclick={() => trackEvent('stories_story_opened', { story_id: story.id, dialect: story.dialect, difficulty: story.difficulty, is_completed: isCompleted })}
 						class="group relative flex flex-col bg-tile-400 border rounded-xl p-4 shadow-sm hover:bg-tile-500 hover:shadow-lg transition-all duration-200 hover:-translate-y-1 motion-reduce:hover:translate-y-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300 {isCompleted ? 'border-green-500/50 hover:border-green-500/80' : 'border-tile-500 hover:border-tile-500'}"
 					>
 						{#if isCompleted}

--- a/src/routes/stories/[story]/+page.svelte
+++ b/src/routes/stories/[story]/+page.svelte
@@ -11,6 +11,7 @@
 	import AudioButton from '$lib/components/AudioButton.svelte';
 	import ArabicWordDisplay from '$lib/components/dialect-shared/story/components/ArabicWordDisplay.svelte';
 	import { Mode, type KeyWord } from '$lib/types/index';
+	import { trackEvent } from '$lib/analytics';
 
 	let { data, activeWordObj = $bindable({
 		english: '',
@@ -233,6 +234,7 @@
 								<input
 									type="checkbox"
 									bind:checked={showEnglish}
+									onchange={() => trackEvent('stories_display_toggled', { setting_name: 'english', enabled: showEnglish, story_type: 'static' })}
 									class="sr-only peer"
 								/>
 								<div class="w-10 h-5 bg-tile-600 rounded-full peer peer-checked:bg-blue-500 transition-colors"></div>
@@ -247,6 +249,7 @@
 								<input
 									type="checkbox"
 									bind:checked={showTransliteration}
+									onchange={() => trackEvent('stories_display_toggled', { setting_name: 'transliteration', enabled: showTransliteration, story_type: 'static' })}
 									class="sr-only peer"
 								/>
 								<div class="w-10 h-5 bg-tile-600 rounded-full peer peer-checked:bg-blue-500 transition-colors"></div>
@@ -262,6 +265,7 @@
 								<input
 									type="checkbox"
 									bind:checked={showTashkeel}
+									onchange={() => trackEvent('stories_display_toggled', { setting_name: 'tashkeel', enabled: showTashkeel, story_type: 'static' })}
 									class="sr-only peer"
 								/>
 								<div class="w-10 h-5 bg-tile-600 rounded-full peer peer-checked:bg-blue-500 transition-colors"></div>

--- a/src/routes/tutor/+page.svelte
+++ b/src/routes/tutor/+page.svelte
@@ -12,6 +12,7 @@
   import type { DialectComparisonSchema } from '$lib/utils/gemini-schemas';
   import { getDefaultDialect } from '$lib/helpers/get-default-dialect';
   import { updateKeyboardStyle } from '$lib/helpers/update-keyboard-style';
+  import { trackEvent } from '$lib/analytics';
   import { TUTOR_SCENARIOS, type TutorScenario } from '$lib/constants/tutor-scenarios';
 
   let { data } = $props();
@@ -40,7 +41,8 @@
   async function handleWordClick(word: string, type: 'arabic' | 'english' | 'transliteration', message: ConversationMessage) {
     const cleanWord = word.replace(/[،,]/g, '');
     const isSingleWordDefinition = type === 'arabic' && cleanWord.trim().split(/\s+/).filter(Boolean).length === 1;
-    
+    trackEvent('tutor_word_definition_requested', { word: cleanWord, type, dialect: selectedDialect });
+
     setActiveWord({
       english: '',
       arabic: '',
@@ -163,6 +165,7 @@
 
   function toggleAutoPlay() {
     autoPlayAudio = !autoPlayAudio;
+    trackEvent('tutor_autoplay_toggled', { enabled: autoPlayAudio });
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem('tutor-autoplay', autoPlayAudio ? 'on' : 'off');
     }
@@ -180,6 +183,7 @@
     const dialog = scenario.dialogs[selectedDialect];
     if (!dialog) return;
 
+    trackEvent('tutor_scenario_started', { scenario_id: scenario.id, dialect: selectedDialect });
     activeScenarioContext = scenario;
     hintsVisible = true;
     currentHint = null;
@@ -218,6 +222,7 @@
   }
 
   function exitScenario() {
+    trackEvent('tutor_scenario_exited', { scenario_id: activeScenarioContext?.id, dialect: selectedDialect });
     activeScenarioContext = null;
     currentHint = null;
     isLoadingHint = false;
@@ -225,6 +230,7 @@
 
   function toggleHints() {
     hintsVisible = !hintsVisible;
+    trackEvent('tutor_hints_toggled', { visible: hintsVisible });
     // Hints aren't fetched while hidden, so catch up when they're shown again.
     if (hintsVisible && !currentHint && !isLoadingHint && conversation.some((m) => m.type === 'tutor')) {
       fetchNextHint();
@@ -364,6 +370,7 @@
     if (practiceIndex < filteredPracticeSentences.length - 1) {
       practiceIndex++;
       practiceResult = null;
+      trackEvent('tutor_practice_navigated', { direction: 'next' });
     }
   }
 
@@ -371,12 +378,14 @@
     if (practiceIndex > 0) {
       practiceIndex--;
       practiceResult = null;
+      trackEvent('tutor_practice_navigated', { direction: 'previous' });
     }
   }
 
   function shufflePracticeSentences() {
     practiceIndex = Math.floor(Math.random() * filteredPracticeSentences.length);
     practiceResult = null;
+    trackEvent('tutor_practice_sentence_shuffled');
   }
 
   // Calculate text similarity (simple word-level comparison)
@@ -433,6 +442,7 @@
       isPracticeRecording = true;
       audioChunks = [];
       practiceResult = null;
+      trackEvent('tutor_practice_recording_started', { dialect: selectedDialect });
     } catch (error) {
       console.error('Error starting practice recording:', error);
     }
@@ -494,6 +504,7 @@
         similarity,
         feedback
       };
+      trackEvent('tutor_practice_submitted', { similarity, correct: similarity >= 70, dialect: selectedDialect });
 
     } catch (error) {
       console.error('Error processing practice recording:', error);
@@ -526,6 +537,7 @@
   let comparisonError = $state<string | null>(null);
 
   async function compareDialects(text: string, english?: string, transliteration?: string) {
+    trackEvent('tutor_dialect_comparison_opened', { dialect: selectedDialect });
     isComparing = true;
     isComparisonModalOpen = true;
     comparisonData = null;
@@ -579,6 +591,7 @@
       }
     }
     
+    trackEvent('tutor_dialect_changed', { dialect });
     selectedDialect = dialect as Dialect;
     conversation = [];
     conversationId = null; // Reset for new dialect
@@ -619,6 +632,7 @@
       audioChunks = [];
       recordingSeconds = 0;
       recordingTimer = setInterval(() => recordingSeconds++, 1000);
+      trackEvent('tutor_message_sent', { method: 'voice', language, dialect: selectedDialect });
     } catch (error) {
       console.error('Error starting recording:', error);
       recording = false;
@@ -896,6 +910,7 @@
 
     isProcessing = true;
     resetTypedInput();
+    trackEvent('tutor_message_sent', { method: 'text', language: inputLanguage, dialect: selectedDialect });
     try {
       await sendUserMessage(text, inputLanguage);
     } finally {
@@ -906,6 +921,7 @@
   // Pre-fill the composer with the current hint so the user can send or tweak it.
   function useHintInComposer() {
     if (!currentHint) return;
+    trackEvent('tutor_hint_used', { dialect: selectedDialect });
     inputMode = 'text';
     keyboard = 'physical';
     inputLanguage = 'ar';
@@ -1037,12 +1053,14 @@
 
   function discardConversation() {
     if (confirm('Discard this conversation without saving?')) {
+      trackEvent('tutor_conversation_discarded', { message_count: conversation.length, dialect: selectedDialect });
       actuallyCloseConversation();
     }
   }
   
   async function saveSummaryAndWords(selectedWords: VocabularyWord[]) {
     isSavingSession = true;
+    trackEvent('tutor_conversation_ended_saved', { dialect: selectedDialect, saved_words_count: selectedWords.length });
     try {
       const response = await fetch('/api/tutor-save-session', {
         method: 'POST',
@@ -1072,6 +1090,7 @@
   }
 
   async function playTutorAudio(text: string, dialect: Dialect, messageId?: string) {
+    trackEvent('tutor_audio_played', { dialect, auto_play: autoPlayAudio });
     try {
       const res = await fetch('/api/text-to-speech', {
         method: 'POST',

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -42,6 +42,10 @@ const config = {
 				})
 			: adapterVercel({ runtime: 'nodejs20.x' }),
 
+		paths: {
+			relative: false
+		},
+
 		csrf: {
 			checkOrigin: false
 		},


### PR DESCRIPTION
## Summary

Adds liberal client-side PostHog event tracking across the five learning surfaces — **lessons, review, tutor, sentences, and stories** (browse + AI-generated) — so we can see generation funnels, answer correctness, navigation, and feature usage (audio, definitions, dialect comparison, hints, toggles).

This branch also bundles the PostHog **base setup** it builds on (deps, client/server init, `/ingest` proxy, baseline server-side captures) plus the unrelated `persist generated content` commit already on the branch.

## How it works

- **New `src/lib/analytics.ts`** — a thin `trackEvent(name, props)` wrapper around `posthog.capture`, SSR-safe (`browser` guard) and error-swallowing so analytics can never break the app. Single chokepoint.
- **Flat `snake_case` event names** matching the existing convention, prefixed per route family (`lessons_*`, `review_*`, `tutor_*`, `sentences_*`, `stories_*`/`story_*`).
- **No duplication** of existing server-side events (`lesson_started`, `word_reviewed`, `word_saved`, `tutor_session_saved` fire untouched).
- **Shared components** (`ReviewCard`, `SentenceBlock`, `SentenceQuiz`, `InteractiveExercise`, `ArabicWordDisplay`, `StoryAudioButton`) instrumented once to cover every route that renders them.

## Events added (~85)

| Area | Sample events |
|------|---------------|
| Lessons | `lessons_path_selected`, `lessons_lesson_opened`, `lessons_paywall_triggered`, `lessons_exercise_submitted` (with `is_correct`), filter/sort/search |
| Review | `review_word_answered`, `review_session_completed`, `review_*_generation_started`, `review_card_*` (flip/definition/comparison/stats), `review_word_deleted`, `review_import_*` |
| Tutor | `tutor_message_sent` (voice/text), `tutor_scenario_started/exited`, `tutor_practice_submitted` (with `similarity`), `tutor_dialect_changed`, `tutor_conversation_ended_saved` |
| Sentences | `sentences_generation_started/completed`, `sentences_typing_completed_correct`, `sentences_reorder_submitted`, `sentences_quiz_answer_selected`, audio/hint/tashkeel/comparison |
| Stories | `stories_topic_card_clicked`, `stories_generation_started/succeeded/failed`, `stories_story_opened/resumed`, filters, display toggles |
| Generated story | `story_viewed`, `story_quiz_answer_submitted`, `story_completed`, `story_word_definition_requested`, `story_audio_played` |

## Verification

- `npm run check`: instrumentation adds **zero real type errors** — every `.svelte` error location is byte-identical to the pre-existing 237-error baseline, and `analytics.ts` is clean.
- To confirm end-to-end: run the app, exercise a flow, and watch for `POST /ingest/` requests carrying the new event names in the Network tab.

## Notes
- `SaveButton` (save sentence/word to deck) was left client-uninstrumented — it already triggers server-side `word_saved`.
- Includes a scratch `posthog-setup-report.md` and the `.claude/skills/integration-sveltekit/` skill dir per the chosen "everything as-is" scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)