### PR TITLE
Sentence trace mode, testimonials carousel & non-Stripe subscriber skip

### DIFF
--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -1,0 +1,108 @@
+@startuml parallel-arabic-architecture
+title Parallel-Arabic — High-Level Architecture
+
+skinparam componentStyle rectangle
+skinparam shadowing false
+skinparam defaultTextAlignment center
+skinparam rectangle {
+  BorderColor #555555
+}
+
+' ---------- CLIENTS ----------
+package "Client Layer" {
+  [Web App\n(SvelteKit + Svelte 5 UI)] as Web
+  [Mobile App\n(Capacitor iOS / Android)] as Mobile
+}
+
+' ---------- APPLICATION ----------
+package "Parallel-Arabic Application (SvelteKit)" {
+  [hooks.server.ts\n(auth guard, PostHog proxy, redirects)] as Hooks
+  [Route Pages\n(lessons, stories, tutor, speak,\nvocab, games, leaderboard)] as Pages
+  [API Routes /api/*\n(content gen, TTS/STT, payments,\nauth sync, webhooks)] as API
+  [Cron Jobs\n(daily challenges, weekly reset,\nstreak reminders)] as Cron
+  [Server libs\n(audio-generation, email,\nredis, challenge-generator)] as ServerLib
+}
+
+' ---------- HOSTING ----------
+package "Deployment / Hosting" {
+  node "Vercel\n(primary host + cron scheduler)" as Vercel
+  node "Fly.io\n(Docker / adapter-node alt host)" as Fly
+}
+
+' ---------- THIRD PARTY ----------
+package "Data & Infra (3rd party)" {
+  database "Supabase\nPostgres DB · Auth · Storage" as Supabase
+  database "Redis\n(caching)" as Redis
+}
+
+package "AI / Speech (3rd party)" {
+  cloud "Google Gemini\n(text generation)" as Gemini
+  cloud "ElevenLabs\n(TTS + Conversational AI tutor)" as Eleven
+  cloud "Google Cloud Speech\n(speech-to-text)" as GSpeech
+}
+
+package "Payments / Auth providers (3rd party)" {
+  cloud "Stripe\n(web subscriptions + webhook)" as Stripe
+  cloud "RevenueCat\n(mobile IAP + webhook)" as RevenueCat
+  cloud "Google OAuth" as GoogleOAuth
+  cloud "Apple Sign-In / IAP" as Apple
+}
+
+package "Comms · Analytics · Content (3rd party)" {
+  cloud "Mailgun\n(transactional email)" as Mailgun
+  cloud "PostHog\n(product analytics, proxied)" as PostHog
+  cloud "Vercel Analytics\n+ Speed Insights" as VercelAna
+  cloud "Sentry\n(error monitoring — configured, disabled)" as Sentry
+  cloud "YouTube\n(transcript / shorts ingestion)" as YouTube
+}
+
+' ---------- CLIENT -> APP ----------
+Web --> Hooks
+Mobile --> Hooks
+Mobile --> RevenueCat
+Mobile --> Apple
+
+' ---------- APP INTERNAL ----------
+Hooks --> Pages
+Hooks --> API
+Pages --> API
+Vercel ..> Cron : schedules
+Cron --> API
+
+' ---------- HOSTING ----------
+Web .. Vercel
+API .. Vercel
+API .. Fly
+
+' ---------- DATA ----------
+Hooks --> Supabase
+API --> Supabase
+ServerLib --> Supabase
+API --> Redis
+ServerLib --> Redis
+
+' ---------- AI / SPEECH ----------
+API --> Gemini
+ServerLib --> Gemini
+ServerLib --> Eleven
+API --> Eleven
+API --> GSpeech
+
+' ---------- PAYMENTS / AUTH ----------
+API --> Stripe
+API --> RevenueCat
+Hooks --> GoogleOAuth
+API --> GoogleOAuth
+API --> Apple
+Stripe ..> API : webhook
+RevenueCat ..> API : webhook
+
+' ---------- COMMS / ANALYTICS / CONTENT ----------
+ServerLib --> Mailgun
+Web --> PostHog
+Hooks --> PostHog
+Web --> VercelAna
+API ..> Sentry : on error (disabled)
+API --> YouTube
+
+@enduml

--- a/scripts/sync-stripe-subscriptions.ts
+++ b/scripts/sync-stripe-subscriptions.ts
@@ -48,7 +48,7 @@ interface SyncResult {
   userId: string;
   email: string;
   subscriberId: string;
-  status: 'updated' | 'skipped' | 'error' | 'not_found';
+  status: 'updated' | 'skipped' | 'error' | 'not_found' | 'skipped_non_stripe';
   changes: {
     is_subscriber?: { old: boolean; new: boolean };
     subscription_end_date?: { old: number | null; new: number | null };
@@ -190,10 +190,29 @@ async function syncAllSubscriptions(dryRun: boolean = false, specificUserId?: st
     let skipped = 0;
     let errors = 0;
     let notFound = 0;
+    let skippedNonStripe = 0;
 
     // Process each user
     for (const user of users) {
       if (!user.subscriber_id) continue;
+
+      // Only Stripe subscriptions are handled here. Stripe subscription IDs
+      // always start with "sub_"; anything else (e.g. Apple/RevenueCat) is
+      // skipped so we don't call stripe.subscriptions.retrieve() on an ID
+      // Stripe doesn't recognize.
+      if (!user.subscriber_id.startsWith('sub_')) {
+        console.log(`Skipping non-Stripe subscriber: ${user.email || user.id} (${user.subscriber_id})`);
+        console.log('');
+        skippedNonStripe++;
+        results.push({
+          userId: user.id,
+          subscriberId: user.subscriber_id,
+          email: user.email || '',
+          status: 'skipped_non_stripe',
+          changes: {}
+        });
+        continue;
+      }
 
       console.log(`Processing user: ${user.email || user.id} (${user.subscriber_id})`);
 
@@ -251,6 +270,7 @@ async function syncAllSubscriptions(dryRun: boolean = false, specificUserId?: st
     console.log(`   ⏭️  Skipped: ${skipped}`);
     console.log(`   ❌ Errors: ${errors}`);
     console.log(`   ⚠️  Not found: ${notFound}`);
+    console.log(`   🍎 Skipped (non-Stripe): ${skippedNonStripe}`);
     console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
 
     if (dryRun && updated > 0) {

--- a/src/lib/components/dialect-shared/sentences/SentenceBlock.svelte
+++ b/src/lib/components/dialect-shared/sentences/SentenceBlock.svelte
@@ -51,12 +51,18 @@
 		correct: boolean;
 	};
 
-	// Practice Mode State - defaults to reorder (beginner-friendly)
-	type PracticeMode = 'typing' | 'reorder';
-	let practiceMode = $state<PracticeMode>('reorder');
+	// Practice Mode State - defaults to trace (guided writing)
+	type PracticeMode = 'typing' | 'reorder' | 'trace';
+	let practiceMode = $state<PracticeMode>('trace');
+
+	// Modes that use the keyboard (virtual or native) for free-form input
+	let usesKeyboard = $derived(practiceMode === 'typing' || practiceMode === 'trace');
 
 	let attempt: Attempt[] = $state([]);
 	let attemptTemp: Attempt[] = $state([]);
+
+	// Trace mode: the live input, used to "fill in" the dimmed target answer
+	let traceInput = $state('');
 	let keyboard = $state<'virtual' | 'physical'>('virtual');
 	
 	// Detect mobile on mount and default to native keyboard
@@ -211,6 +217,9 @@
 	}
 
 	function compareMyInput(value: string) {
+		// Drive trace-mode "fill in" feedback from the same input
+		traceInput = value;
+
 		// Use strict normalization for final comparison
 		const normalizedInput = normalizeArabicText(value.trim());
 		const normalizedTarget = normalizeArabicText(sentence.arabic.trim());
@@ -249,7 +258,7 @@
 		if (areArraysEqual(myInputArr, arabicArr) && value.trim().length > 0) {
 			isCorrect = true;
 			// Reset virtual keyboard if it exists and is active
-			if (keyboard === 'virtual' && practiceMode === 'typing' && keyboardContainer) {
+			if (keyboard === 'virtual' && usesKeyboard && keyboardContainer) {
 				const keyboardEl = keyboardContainer.querySelector('arabic-keyboard') as Keyboard | null;
 				if (keyboardEl && typeof keyboardEl.resetValue === 'function') {
 					keyboardEl.resetValue();
@@ -264,7 +273,7 @@
 
 	function checkInput() {
 		// Only check virtual keyboard when it's active
-		if (keyboard !== 'virtual' || practiceMode !== 'typing') return;
+		if (keyboard !== 'virtual' || !usesKeyboard) return;
 		
 		// Get the keyboard element fresh each time to ensure it exists
 		const keyboardEl = keyboardContainer?.querySelector('arabic-keyboard') as Keyboard | null;
@@ -308,6 +317,38 @@
 	});
 
 	const isSafari = getBrowserInfo();
+
+	// Trace mode: map each target character to a fill-in state based on input.
+	// 'pending' = not yet reached (dimmed), 'correct' = filled in, 'incorrect' = red.
+	let traceChars = $derived.by(() => {
+		const target = sentence.arabic.trim();
+		const lightTarget = normalizeArabicTextLight(target).split('');
+		const lightInput = normalizeArabicTextLight(traceInput.trim()).split('');
+
+		return target.split('').map((char, i) => {
+			let state: 'pending' | 'correct' | 'incorrect';
+			if (i >= lightInput.length) {
+				state = 'pending';
+			} else {
+				state = lightInput[i] === lightTarget[i] ? 'correct' : 'incorrect';
+			}
+			return { char, state };
+		});
+	});
+
+	let traceHtml = $derived(
+		traceChars
+			.map(({ char, state }) => {
+				const cls = cn('text-2xl sm:text-3xl transition-opacity duration-150', {
+					'text-text-300': state === 'correct',
+					'text-red-500': state === 'incorrect',
+					'text-text-300 opacity-40': state === 'pending'
+				});
+				const content = isSafari ? `&zwj;&zwj;${char}&zwj;&zwj;` : char;
+				return `<span class="${cls}">${content}</span>`;
+			})
+			.join('')
+	);
 
 	function openInfoModal() {
 		isInfoModalOpen = true;
@@ -551,11 +592,12 @@
 		practiceMode = newMode;
 		isCorrect = false;
 		
-		// Reset typing mode state
+		// Reset typing/trace mode state
 		attemptTemp = [];
 		attempt = [];
 		keyboardValue = '';
-		
+		traceInput = '';
+
 		// Reset reorder mode state
 		if (newMode === 'reorder') {
 			initializeShuffledWords();
@@ -591,7 +633,8 @@
 			targetWord = '';
 			targetArabicWord = '';
 			keyboardValue = '';
-			
+			traceInput = '';
+
 			// Clear selection state
 			selectedWords = [];
 			isSelecting = false;
@@ -606,7 +649,7 @@
 
 			if (typeof document !== 'undefined') {
 				// Reset virtual keyboard if it exists and is active
-				if (keyboard === 'virtual' && practiceMode === 'typing' && keyboardContainer) {
+				if (keyboard === 'virtual' && usesKeyboard && keyboardContainer) {
 					const container = keyboardContainer; // Capture for closure
 					setTimeout(() => {
 						const keyboardEl = container.querySelector('arabic-keyboard') as Keyboard | null;
@@ -635,7 +678,7 @@
 	
 	// Update keyboard styles when keyboard type changes or container is ready
 	$effect(() => {
-		if (keyboardContainer && keyboard === 'virtual' && practiceMode === 'typing') {
+		if (keyboardContainer && keyboard === 'virtual' && usesKeyboard) {
 			// Capture the container reference for the setTimeout closure
 			const container = keyboardContainer;
 			// Use setTimeout to ensure DOM is updated
@@ -741,7 +784,7 @@
 	{#if isCorrect}
 		<div class="mb-4 bg-green-100 py-3 px-4 text-center border-2 border-green-100 rounded-lg flex items-center justify-between gap-4">
 			<p class="text-lg font-bold text-text-300">
-				{#if practiceMode === 'typing'}
+				{#if usesKeyboard}
 					{sentence.arabic} is Correct!
 				{:else}
 					Sentence arranged correctly!
@@ -780,6 +823,20 @@
 				<span>Typing</span>
 			</button>
 			<button
+				onclick={() => handleModeChange('trace')}
+				class={cn(
+					"flex items-center gap-2 px-4 py-2.5 rounded-lg font-semibold transition-all duration-200 border-2",
+					practiceMode === 'trace'
+						? "bg-sky-600 text-white border-sky-500 shadow-lg"
+						: "bg-tile-300 text-text-300 border-tile-500 hover:bg-tile-500 hover:border-tile-600"
+				)}
+			>
+				<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke-dasharray="3 3" d="M4 20h16M4 20l4-12 4 8 4-12 4 16"></path>
+				</svg>
+				<span>Trace</span>
+			</button>
+			<button
 				onclick={() => handleModeChange('reorder')}
 				class={cn(
 					"flex items-center gap-2 px-4 py-2.5 rounded-lg font-semibold transition-all duration-200 border-2",
@@ -794,14 +851,6 @@
 				<span>Sentence Reorder</span>
 			</button>
 		</div>
-	</div>
-	
-	<!-- Multi-word selection instructions -->
-	<div class="mb-4 p-3 bg-tile-400 border-l-4 border-tile-500 rounded-r hover:bg-tile-500 transition-colors duration-300">
-		<p class="text-sm text-text-300">
-			<strong>💡 Tip:</strong> Click individual words for definitions, or 
-			<strong>click and drag across multiple words</strong> to select a phrase and get its definition!
-		</p>
 	</div>
 	
 	<div class="flex flex-wrap items-center justify-center gap-2 mb-6 p-3 bg-tile-400 rounded-xl border border-tile-500">
@@ -893,11 +942,17 @@
 		</button>
 	</div>
 	
-	<!-- ==================== TYPING MODE ==================== -->
-	{#if practiceMode === 'typing'}
+	<!-- ==================== TYPING / TRACE MODE ==================== -->
+	{#if usesKeyboard}
 	<div class="text-center mb-6">
 		{@render englishWordDisplay()}
-		
+
+		{#if practiceMode === 'trace'}
+			<!-- Trace mode: dimmed answer that fills in as you type -->
+			<div class="mt-4" dir="rtl">
+				<span class="font-arabic leading-loose">{@html traceHtml}</span>
+			</div>
+		{:else}
 		<div class="mt-4">
 			{#if isSafari}
 				<span class="text-2xl sm:text-3xl">
@@ -925,6 +980,7 @@
 				</span>
 			{/if}
 		</div>
+		{/if}
 	</div>
 
 	<Modal isOpen={isInfoModalOpen} handleCloseModal={closeInfoModal} height="70%" width="80%">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -3,6 +3,8 @@
 <script>
 	import { slide } from 'svelte/transition';
 
+	/** @typedef {{ t: string; b?: boolean }} QuoteSegment */
+
 	/** @type {number | null} */
 	let openIndex = $state(null);
 
@@ -10,6 +12,46 @@
 	function toggle(i) {
 		openIndex = openIndex === i ? null : i;
 	}
+
+	// Testimonials — each is an array of text segments; `b: true` renders bold.
+	const testimonials = [
+		[
+			{ t: 'After only a day, I love Parallel Arabic.', b: true },
+			{ t: ' As a language teacher — I teach French at a huge public high school in Southern California — and an absolute language nut who speaks seven other languages besides Arabic, I can tell how much thought went into this.' }
+		],
+		[
+			{ t: 'Wow this is perfect for what I need currently. The stories section in particular is a great idea as ' },
+			{ t: "I can't find any graded stories for practice.", b: true },
+			{ t: ' Thank you so much for this :)' }
+		],
+		[
+			{ t: 'This is great! As someone outgrowing Duolingo this is perfect.', b: true }
+		],
+		[
+			{ t: 'I love it! This is something I have been ' },
+			{ t: 'searching for ages', b: true },
+			{ t: ' :) thank you so much' }
+		],
+		[
+			{ t: "Have tried many of the 'apps' and " },
+			{ t: 'this is the closest one to doing what I want!', b: true },
+			{ t: " Very useful and comprehensive app, everything's very useful — I love the interlinear format for the stories." }
+		],
+		[
+			{ t: "Even though I'm a beginner, " },
+			{ t: "your AI is the best I've tried among all the apps!", b: true },
+			{ t: ' The others are always weird in their answers and pronounce the words weirdly.' }
+		],
+		[
+			{ t: 'Stories UI is really good!', b: true },
+			{ t: ' The large, readable font, easy switching of transliteration and English, and interactive click-to-define are all really excellent.' }
+		],
+		[
+			{ t: 'I really like the website and find it very useful. For me ' },
+			{ t: "it's better than a lot of other platforms", b: true },
+			{ t: " — it's well thought out and has a lot of features." }
+		]
+	];
 
 	const faqs = [
 		{
@@ -60,6 +102,31 @@
 			</div>
 		</div>
 	</header>
+
+	{#snippet quoteCard(/** @type {QuoteSegment[]} */ segments, /** @type {boolean} */ hidden)}
+		<figure
+			class="flex-shrink-0 w-[280px] sm:w-[320px] bg-tile-400 rounded-xl p-5 sm:p-6 shadow-sm"
+			aria-hidden={hidden}
+		>
+			<span class="block text-4xl leading-none text-text-200 mb-2" aria-hidden="true">“</span>
+			<blockquote class="text-text-300 text-base leading-relaxed"
+				>{#each segments as seg, i (i)}{#if seg.b}<strong class="text-text-200">{seg.t}</strong>{:else}{seg.t}{/if}{/each}</blockquote
+			>
+		</figure>
+	{/snippet}
+
+	<!-- Testimonials — infinite horizontal marquee -->
+	<section class="py-10 sm:py-14 bg-tile-200 border-y border-tile-500 overflow-hidden">
+		<div class="max-w-6xl mx-auto px-4 sm:px-8 mb-6 sm:mb-8">
+			<h2 class="text-2xl sm:text-4xl font-bold text-text-300 tracking-tight">What our users say</h2>
+		</div>
+		<div class="marquee">
+			<div class="marquee__track">
+				{#each testimonials as t, i (i)}{@render quoteCard(t, false)}{/each}
+				{#each testimonials as t, i (i)}{@render quoteCard(t, true)}{/each}
+			</div>
+		</div>
+	</section>
 
 	<!-- Features — irregular bento grid (was 8 identical full-width cards) -->
 	<section class="py-14 sm:py-20 bg-tile-200 border-t border-tile-500">
@@ -250,35 +317,6 @@
 		</div>
 	</section>
 
-	<!-- Testimonials — offset quotes (was 3 equal bordered cards) -->
-	<section class="py-14 sm:py-20 bg-tile-200 border-y border-tile-500">
-		<div class="max-w-6xl mx-auto px-4 sm:px-8">
-			<h2 class="text-2xl sm:text-4xl font-bold text-text-300 tracking-tight mb-10">What our learners say</h2>
-			<div class="grid grid-cols-1 md:grid-cols-3 gap-5 sm:gap-6 items-start">
-				<figure class="bg-tile-400 rounded-xl p-6 sm:p-7 shadow-sm">
-					<span class="block text-4xl leading-none text-text-200 mb-2" aria-hidden="true">“</span>
-					<blockquote class="text-text-300 text-base leading-relaxed">
-						Wow this is perfect for what I need currently. The stories section in particular is a great idea as <strong class="text-text-200">I can't find any graded stories for practice</strong>. Thank you so much for this :)
-					</blockquote>
-				</figure>
-
-				<figure class="bg-tile-400 rounded-xl p-6 sm:p-7 shadow-sm md:mt-8">
-					<span class="block text-4xl leading-none text-text-200 mb-2" aria-hidden="true">“</span>
-					<blockquote class="text-text-300 text-base leading-relaxed">
-						<strong class="text-text-200">This is great! As someone outgrowing Duolingo this is perfect.</strong>
-					</blockquote>
-				</figure>
-
-				<figure class="bg-tile-400 rounded-xl p-6 sm:p-7 shadow-sm md:mt-4">
-					<span class="block text-4xl leading-none text-text-200 mb-2" aria-hidden="true">“</span>
-					<blockquote class="text-text-300 text-base leading-relaxed">
-						I love it! This is something I have been <strong class="text-text-200">searching for ages</strong> :) thank you so much
-					</blockquote>
-				</figure>
-			</div>
-		</div>
-	</section>
-
 	<!-- Pricing — softened (was heavy bordered cards) -->
 	<section class="py-14 sm:py-20 bg-tile-300">
 		<div class="max-w-5xl mx-auto px-4 sm:px-8">
@@ -371,3 +409,46 @@
 		</div>
 	</section>
 </div>
+
+<style>
+	.marquee {
+		display: flex;
+		overflow: hidden;
+		-webkit-mask-image: linear-gradient(to right, transparent, black 4%, black 96%, transparent);
+		mask-image: linear-gradient(to right, transparent, black 4%, black 96%, transparent);
+	}
+
+	.marquee__track {
+		display: flex;
+		align-items: stretch;
+		gap: 1rem;
+		width: max-content;
+		padding: 0 0.5rem;
+		animation: marquee-scroll 55s linear infinite;
+	}
+
+	.marquee:hover .marquee__track,
+	.marquee:focus-within .marquee__track {
+		animation-play-state: paused;
+	}
+
+	@keyframes marquee-scroll {
+		from {
+			transform: translateX(0);
+		}
+		to {
+			transform: translateX(-50%);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.marquee {
+			-webkit-mask-image: none;
+			mask-image: none;
+			overflow-x: auto;
+		}
+		.marquee__track {
+			animation: none;
+		}
+	}
+</style>

--- a/src/routes/generated_story/[id]/+page.svelte
+++ b/src/routes/generated_story/[id]/+page.svelte
@@ -617,24 +617,6 @@
           </div>
         {/if}
 
-        <!-- English translation with drag-to-select -->
-        {#if sentenceEnglish}
-          <div class="mb-4 pb-3 border-b border-tile-600">
-            <Sentence
-              {sentence}
-              {setActiveWord}
-              type="english"
-              index={sentenceIndex}
-              {mode}
-              isGenerated={true}
-              dialect={storyDialect as any}
-              classname="!bg-transparent !border-0 !shadow-none !p-0"
-              innerClassname="justify-center"
-              size="sm"
-            />
-          </div>
-        {/if}
-
         <!-- Arabic word display with drag-and-define -->
         {#if !sentence.wordAlignments?.length && sentenceTransliteration}
           <p class="text-base sm:text-lg text-text-200 italic text-center mb-3 leading-relaxed">


### PR DESCRIPTION
## Summary

Bundles UI improvements with a Stripe sync fix on this branch.

### Sentence practice — Trace mode
- New **Trace** practice mode (now the default) in `SentenceBlock`: the target Arabic answer is shown dimmed (~40% opacity) and "fills in" to full opacity as you type, with mismatches marked red — like tracing.
- Reuses the existing **virtual + native keyboard** input path and the same normalization/comparison logic, so completion still triggers the correct-answer banner and XP award.

### About page — testimonials
- Reworked the testimonials into an **infinite horizontal marquee** (CSS-only, pauses on hover/focus, edge fade masks, `prefers-reduced-motion` fallback), moved **directly below the hero**, and tightened spacing — fixing the large empty grid gaps.
- Added new learner quotes (incl. a reworded language-teacher testimonial).

### Stripe sync + misc
- `sync-stripe-subscriptions`: skip subscriber IDs that don't start with `sub_` (e.g. Apple/RevenueCat) so Stripe isn't queried with IDs it doesn't recognize; reports a `skipped_non_stripe` count.
- `generated_story`: removed the English translation block from the sentence view.
- Added `docs/architecture.puml`.

> Note: two local `return true` short-circuits in the subscription helpers were intentionally **excluded** (they disabled sub gating for all users).

## Test plan
- [ ] Sentences → Write: Trace mode is default; typing fills in the dimmed answer and flags wrong chars red; completing awards XP. Virtual + native keyboards both work. Typing/Reorder still work.
- [ ] About page: testimonials scroll seamlessly below the hero, pause on hover, and reflow with reduced motion.
- [ ] Run sync script (dry run): non-`sub_` subscribers are skipped and counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)