### PR TITLE
ai isnt cool

### DIFF
--- a/src/lib/components/PaywallModal.svelte
+++ b/src/lib/components/PaywallModal.svelte
@@ -49,7 +49,7 @@
             </li>
             <li class="flex items-start gap-3">
                 <div class="shrink-0 mt-1"><Checkmark /></div>
-                <span><strong class="text-text-300">Unlimited AI-generated practice sentences</strong> for all skill levels</span>
+                <span><strong class="text-text-300">Unlimited sentence mining</strong> for all skill levels</span>
             </li>
             <li class="flex items-start gap-3">
                 <div class="shrink-0 mt-1"><Checkmark /></div>

--- a/src/lib/components/dialect-shared/lesson/components/CreateLessonModal.svelte
+++ b/src/lib/components/dialect-shared/lesson/components/CreateLessonModal.svelte
@@ -272,8 +272,8 @@
 			
 			// Set user-friendly error messages based on error type
 			if (errorMsg.includes('Failed to parse JSON')) {
-				generationError = 'AI Response Format Error';
-				errorDetails = 'The AI generated content in an unexpected format. This is usually temporary. Please try again, and if the issue persists, try adjusting your topic or selecting a shorter lesson length.';
+				generationError = 'Content Format Error';
+				errorDetails = 'We hit an unexpected format while creating your content. This is usually temporary. Please try again, and if the issue persists, try adjusting your topic or selecting a shorter lesson length.';
 			} else if (errorMsg.includes('fetch') || errorMsg.includes('network')) {
 				generationError = 'Connection Error';
 				errorDetails = 'Unable to reach the server. Please check your internet connection and try again.';
@@ -356,7 +356,7 @@
 						{/if}
 					</h2>
 					<p class="text-text-200 text-lg">
-						Using specialized AI to create a custom lesson just for you.
+						Crafting a custom lesson just for you.
 						<span class="block mt-2 text-sm opacity-75">
 							{#if dialect === 'darija' || dialect === 'egyptian-arabic'}
 								This usually takes about 1-2 minutes.
@@ -383,7 +383,7 @@
 			<div class="mb-6 border-b border-tile-500 pb-4">
 				<h1 class="text-2xl font-bold text-text-300 mb-1">Create {dialectName[dialect]} Lesson</h1>
 				<p class="text-text-200 text-sm">
-					Design a custom AI-generated lesson tailored to your needs.
+					Design a custom lesson tailored to your needs.
 				</p>
 			</div>
 			

--- a/src/lib/components/dialect-shared/story/components/CreateStoryModal.svelte
+++ b/src/lib/components/dialect-shared/story/components/CreateStoryModal.svelte
@@ -473,8 +473,8 @@
 			
 			// Set user-friendly error messages based on error type
 			if (errorMsg.includes('Failed to parse JSON')) {
-				generationError = 'AI Response Format Error';
-				errorDetails = 'The AI generated content in an unexpected format. This is usually temporary. Please try again, and if the issue persists, try adjusting your prompt or reducing the content length.';
+				generationError = 'Content Format Error';
+				errorDetails = 'We hit an unexpected format while creating your content. This is usually temporary. Please try again, and if the issue persists, try adjusting your prompt or reducing the content length.';
 			} else if (errorMsg.includes('transcribe')) {
 				generationError = 'Transcription Failed';
 				errorDetails = errorMsg.includes('Audio file too large') 
@@ -575,7 +575,7 @@
 						{/if}
 					</h2>
 					<p class="text-text-200 text-lg">
-						Using specialized AI to create custom content just for you.
+						Crafting custom content just for you.
 						<span class="block mt-2 text-sm opacity-75">
 							{#if dialect === 'darija' || dialect === 'egyptian-arabic'}
 								This usually takes about 1-2 minutes.
@@ -765,7 +765,7 @@
 							selectableFor="generate"
 							isSelected={creationMode === 'generate'}
 							value="generate"
-							text="✨ AI Generate"
+							text="✨ Create"
 						/>
 						<RadioButton
 							className="!text-base !font-medium"

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -381,7 +381,7 @@ Thank you for joining Parallel Arabic! We're excited to help you on your journey
 
 FREE FEATURES:
 - Stories & Conversations: Access to one conversation with native audio
-- AI Practice: 5 AI-generated practice sentences across multiple dialects
+- Sentence Mining: 5 practice sentences across multiple dialects
 - Speaking Practice: Basic pronunciation feedback
 - Verb Conjugation: Practice with one verb
 - Vocabulary: Access to 156 words for writing and quizzes
@@ -396,7 +396,7 @@ Upgrade to Premium for just $10/month and get:
 - Spaced Repetition: Master vocabulary words
 - Interactive Videos: YouTube videos with transcripts & translations
 - All Stories: Unlimited conversations with native audio
-- Unlimited AI Practice: Generate unlimited practice sentences
+- Unlimited Sentence Mining: Practice with unlimited custom sentences
 - Advanced Speaking: Real-time pronunciation feedback
 - All Verbs: Complete verb conjugation practice
 - Anki Decks: Custom flashcard exports

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -158,7 +158,7 @@
 				<article class="md:col-span-1 lg:col-span-2 min-w-0 flex flex-col bg-tile-400 border border-tile-500 rounded-xl p-6 sm:p-7 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg motion-reduce:hover:translate-y-0">
 					<h3 class="text-xl sm:text-2xl font-bold text-text-300 mb-3">Lessons</h3>
 					<p class="text-text-200 leading-relaxed">
-						Explore 50+ structured lessons per dialect covering vocabulary, grammar, and phrases — or use AI to generate lessons on any topic you're interested in.
+						Explore 50+ structured lessons per dialect covering vocabulary, grammar, and phrases — or create custom lessons on any topic you're interested in.
 					</p>
 					<img
 						src="/images/features/lessons.png"
@@ -279,7 +279,7 @@
 						Generic language apps bore you. The same repetitive exercises, the same irrelevant topics…
 					</p>
 					<p class="text-text-300 text-base sm:text-lg leading-relaxed mb-5">
-						<strong>Use AI to generate custom stories and practice sentences built around the words you're actually studying.</strong> Want to practice Egyptian street food vocab? Levantine soccer slang? Generate it instantly. Your words, your context — not someone else's curriculum.
+						<strong>Create custom stories and practice sentences built around the words you're actually studying.</strong> Want to practice Egyptian street food vocab? Levantine soccer slang? Generate it instantly. Your words, your context — not someone else's curriculum.
 					</p>
 					<div class="border-t border-tile-500 pt-4">
 						<p class="text-sm text-text-200 font-medium mb-3">Your saved words include:</p>
@@ -323,7 +323,7 @@
 			<div class="max-w-2xl mb-10 sm:mb-12">
 				<h2 class="text-2xl sm:text-4xl font-bold text-text-300 tracking-tight mb-3">Choose your path</h2>
 				<p class="text-text-200 text-base sm:text-lg leading-relaxed">
-					Start learning for free, forever. Upgrade anytime for unlimited AI-generated content and advanced features.
+					Start learning for free, forever. Upgrade anytime for unlimited custom content and advanced features.
 				</p>
 			</div>
 
@@ -365,7 +365,7 @@
 
 					<ul class="space-y-3 mb-8 flex-grow">
 						<li class="flex items-start gap-3"><span class="text-lg flex-shrink-0" aria-hidden="true">✓</span><span class="text-text-200"><strong class="text-text-300">Everything in Free</strong></span></li>
-						<li class="flex items-start gap-3"><span class="text-lg flex-shrink-0" aria-hidden="true">✓</span><span class="text-text-200"><strong class="text-text-300">Unlimited AI-generated stories</strong> (create custom content)</span></li>
+						<li class="flex items-start gap-3"><span class="text-lg flex-shrink-0" aria-hidden="true">✓</span><span class="text-text-200"><strong class="text-text-300">Unlimited custom stories</strong> (create your own content)</span></li>
 						<li class="flex items-start gap-3"><span class="text-lg flex-shrink-0" aria-hidden="true">✓</span><span class="text-text-200"><strong class="text-text-300">Unlimited AI tutor conversations</strong> with real-time feedback</span></li>
 						<li class="flex items-start gap-3"><span class="text-lg flex-shrink-0" aria-hidden="true">✓</span><span class="text-text-200"><strong class="text-text-300">Advanced spaced repetition</strong> with Anki export</span></li>
 						<li class="flex items-start gap-3"><span class="text-lg flex-shrink-0" aria-hidden="true">✓</span><span class="text-text-200"><strong class="text-text-300">Pronunciation assessment</strong> for speaking practice</span></li>

--- a/src/routes/api/chat-support/+server.ts
+++ b/src/routes/api/chat-support/+server.ts
@@ -84,7 +84,7 @@ The user may ask about grammar rules, vocabulary, pronunciation, culture, or nee
     // Check if it's a 503 error (model overloaded)
     if (e instanceof GeminiApiError && e.is503) {
       return error(503, { 
-        message: 'The AI model is currently overloaded. Please try again in a few moments. We\'re working to handle the high demand.' 
+        message: 'Our service is experiencing high demand. Please try again in a few moments.' 
       });
     }
     

--- a/src/routes/api/definition-sentence/+server.ts
+++ b/src/routes/api/definition-sentence/+server.ts
@@ -156,7 +156,7 @@ MAKE SURE THAT THE RESPONSE IS JSON FORMAT USING THE FOLOWING STRUCTURE
     let responseText = response.text;
     if (!responseText) {
       console.error('Empty response from Gemini API');
-      return error(500, { message: 'Empty response from AI' });
+      return error(500, { message: 'No content was returned. Please try again.' });
     }
 
     // Strip markdown code blocks if present

--- a/src/routes/api/generate-conjugation-example/+server.ts
+++ b/src/routes/api/generate-conjugation-example/+server.ts
@@ -59,7 +59,7 @@ Return PURE JSON only. No markdown code blocks. No explanations.`;
 		return json(parsed);
 	} catch (e) {
 		if (e instanceof GeminiApiError && e.is503) {
-			return error(503, { message: 'The AI model is currently overloaded. Please try again.' });
+			return error(503, { message: 'Our service is currently busy. Please try again.' });
 		}
 		console.error('Error generating conjugation example:', e);
 		const message = e instanceof Error ? e.message : 'Failed to generate example sentence.';

--- a/src/routes/api/generate-conjugations/+server.ts
+++ b/src/routes/api/generate-conjugations/+server.ts
@@ -118,7 +118,7 @@ Return PURE JSON only. No markdown code blocks. No explanations.`;
 	} catch (e) {
 		if (e instanceof GeminiApiError && e.is503) {
 			return error(503, {
-				message: 'The AI model is currently overloaded. Please try again in a few moments.'
+				message: 'Our service is experiencing high demand. Please try again in a few moments.'
 			});
 		}
 		console.error('Error generating conjugations:', e);

--- a/src/routes/api/generate-game-sentences/+server.ts
+++ b/src/routes/api/generate-game-sentences/+server.ts
@@ -272,7 +272,7 @@ export const POST: RequestHandler = async ({ request }) => {
 
     if (err instanceof GeminiApiError && err.is503) {
       return error(503, {
-        message: 'The AI model is currently overloaded. Please try again in a few moments.'
+        message: 'Our service is experiencing high demand. Please try again in a few moments.'
       });
     }
 

--- a/src/routes/api/generate-sentences-egyptian/+server.ts
+++ b/src/routes/api/generate-sentences-egyptian/+server.ts
@@ -367,7 +367,7 @@ export const POST: RequestHandler = async ({ request }) => {
     // Check if it's a 503 error (model overloaded)
     if (e instanceof GeminiApiError && e.is503) {
       return error(503, { 
-        message: 'The AI model is currently overloaded. Please try again in a few moments. We\'re working to handle the high demand.' 
+        message: 'Our service is experiencing high demand. Please try again in a few moments.' 
       });
     }
     

--- a/src/routes/api/generate-sentences/+server.ts
+++ b/src/routes/api/generate-sentences/+server.ts
@@ -412,7 +412,7 @@ IMPORTANT:
     // Check if it's a 503 error (model overloaded)
     if (e instanceof GeminiApiError && e.is503) {
       return error(503, { 
-        message: 'The AI model is currently overloaded. Please try again in a few moments. We\'re working to handle the high demand.' 
+        message: 'Our service is experiencing high demand. Please try again in a few moments.' 
       });
     }
     

--- a/src/routes/api/generate-words/+server.ts
+++ b/src/routes/api/generate-words/+server.ts
@@ -305,7 +305,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     // Check if it's a 503 error (model overloaded)
     if (err instanceof GeminiApiError && err.is503) {
       return error(503, { 
-        message: 'The AI model is currently overloaded. Please try again in a few moments. We\'re working to handle the high demand.' 
+        message: 'Our service is experiencing high demand. Please try again in a few moments.' 
       });
     }
     

--- a/src/routes/api/open-ai/+server.ts
+++ b/src/routes/api/open-ai/+server.ts
@@ -29,7 +29,7 @@ export const POST: RequestHandler = async ({ request }) => {
     // Check if it's a 503 error (model overloaded)
     if (e instanceof GeminiApiError && e.is503) {
       return error(503, { 
-        message: 'The AI model is currently overloaded. Please try again in a few moments. We\'re working to handle the high demand.' 
+        message: 'Our service is experiencing high demand. Please try again in a few moments.' 
       });
     }
     

--- a/src/routes/api/translate-user-message/+server.ts
+++ b/src/routes/api/translate-user-message/+server.ts
@@ -180,7 +180,7 @@ Do not include a suggestedSentence field for English input — the arabic field 
     // Check if it's a 503 error (model overloaded)
     if (e instanceof GeminiApiError && e.is503) {
       return error(503, { 
-        message: 'The AI model is currently overloaded. Please try again in a few moments. We\'re working to handle the high demand.' 
+        message: 'Our service is experiencing high demand. Please try again in a few moments.' 
       });
     }
     

--- a/src/routes/api/tutor-chat/+server.ts
+++ b/src/routes/api/tutor-chat/+server.ts
@@ -218,7 +218,7 @@ IMPORTANT: wordAlignments must have one entry per Arabic word in your response, 
     // Check if it's a 503 error (model overloaded)
     if (e instanceof GeminiApiError && e.is503) {
       return error(503, { 
-        message: 'The AI model is currently overloaded. Please try again in a few moments. We\'re working to handle the high demand.' 
+        message: 'Our service is experiencing high demand. Please try again in a few moments.' 
       });
     }
     

--- a/src/routes/api/tutor-hint/+server.ts
+++ b/src/routes/api/tutor-hint/+server.ts
@@ -111,7 +111,7 @@ Respond as JSON with this exact shape:
   } catch (e) {
     console.error('Tutor hint error:', e);
     if (e instanceof GeminiApiError && e.is503) {
-      return error(503, { message: 'The AI model is currently overloaded. Please try again.' });
+      return error(503, { message: 'Our service is currently busy. Please try again.' });
     }
     return error(500, { message: 'Failed to generate hint.' });
   }

--- a/src/routes/faq/+page.svelte
+++ b/src/routes/faq/+page.svelte
@@ -15,7 +15,7 @@
         '🎥 Videos: Watch Arabic learning videos with interactive sentence breakdowns and vocabulary practice.',
         '💬 Sentence Generation: Generate unlimited practice sentences using your saved vocabulary words for personalized learning.',
         '📚 Guided Lessons: Follow structured learning paths with step-by-step lessons tailored to your chosen dialect and level.',
-        '🎯 Context-Based Learning: Our AI uses your saved words to generate unlimited personalized learning materials - lessons, stories, and practice exercises - all tailored to the vocabulary you\'re actively learning. This means every piece of content reinforces the words you\'ve already saved, making your learning more efficient and effective.'
+        '🎯 Context-Based Learning: Parallel Arabic uses your saved words to create unlimited personalized learning materials - lessons, stories, and practice exercises - all tailored to the vocabulary you\'re actively learning. This means every piece of content reinforces the words you\'ve already saved, making your learning more efficient and effective.'
       ]
     },
     {
@@ -30,7 +30,7 @@
       id: 'why-pay',
       question: 'Why Pay for Parallel Arabic?',
       answer: [
-        'To cover server costs, AI credits, and the creation of learning materials from professional Arabic teachers, including conversations and sentence-by-sentence audio.',
+        'To cover server costs and the creation of learning materials from professional Arabic teachers, including conversations and sentence-by-sentence audio.',
         'You are paying to support an independent designer & developer who is passionate about this project. 100% of your subscription dues goes towards the active development of Parallel Arabic.',
         'If you really want to use the platform but cannot afford it at this time, just email me at selmetwa@gmail.com'
       ]
@@ -70,7 +70,7 @@
     {
       id: 'offline',
       question: 'Can I Use Parallel Arabic Offline?',
-      answer: 'Parallel Arabic is a web application that requires an internet connection. However, once loaded, many features work offline thanks to Progressive Web App (PWA) capabilities. For the best experience, we recommend using it with an internet connection to access all features including AI-powered content.'
+      answer: 'Parallel Arabic is a web application that requires an internet connection. However, once loaded, many features work offline thanks to Progressive Web App (PWA) capabilities. For the best experience, we recommend using it with an internet connection to access all features including personalized content.'
     }
   ];
 

--- a/src/routes/lessons/+page.svelte
+++ b/src/routes/lessons/+page.svelte
@@ -171,7 +171,7 @@
 					Learn Arabic Your Way
 				</h1>
 				<p class="text-text-200 text-lg sm:text-xl leading-snug">
-					Choose your learning path — follow a structured curriculum or create custom AI-powered lessons tailored to your interests.
+					Choose your learning path — follow a structured curriculum or create custom lessons tailored to your interests.
 				</p>
 			</div>
 		</div>
@@ -213,10 +213,10 @@
 						</div>
 						<h3 class="text-xl sm:text-2xl font-bold text-text-300 mb-2">Customizable Lessons</h3>
 						<p class="text-text-200 leading-relaxed mb-4 flex-grow">
-							Create AI-powered lessons on any topic. Search, filter, and browse lessons tailored to your interests and learning goals.
+							Create custom lessons on any topic. Search, filter, and browse lessons tailored to your interests and learning goals.
 						</p>
 						<ul class="space-y-2 text-text-200 mb-5 text-sm">
-							<li class="flex items-center gap-2"><span class="text-purple-500">✓</span><span>AI-generated content</span></li>
+							<li class="flex items-center gap-2"><span class="text-purple-500">✓</span><span>Custom content</span></li>
 							<li class="flex items-center gap-2"><span class="text-purple-500">✓</span><span>Any topic, any level</span></li>
 							<li class="flex items-center gap-2"><span class="text-purple-500">✓</span><span>All 4 Arabic dialects</span></li>
 						</ul>

--- a/src/routes/lessons/custom/+page.svelte
+++ b/src/routes/lessons/custom/+page.svelte
@@ -194,7 +194,7 @@
 				Back to Lessons
 			</a>
 			<h1 class="text-2xl sm:text-3xl text-text-300 font-bold mb-2 tracking-tight">Customizable Lessons</h1>
-			<p class="text-text-200 text-base sm:text-lg leading-relaxed">Create and explore custom AI-generated lessons from all dialects.</p>
+			<p class="text-text-200 text-base sm:text-lg leading-relaxed">Create and explore custom lessons from all dialects.</p>
 		</div>
 
 		<!-- Compact create control (moved onto the title row) -->

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -215,7 +215,7 @@
     { icon: '📖', title: 'Stories & Audio', desc: 'Native audio pronunciation' },
     { icon: '💬', title: 'AI Tutor', desc: 'Real-time conversation practice' },
     { icon: '📺', title: 'Interactive Videos', desc: 'YouTube with transcripts' },
-    { icon: '🤖', title: 'AI Practice', desc: 'Unlimited generated sentences' },
+    { icon: '✨', title: 'Sentence Mining', desc: 'Unlimited practice sentences' },
     { icon: '🎙️', title: 'Speaking', desc: 'Pronunciation feedback' },
     { icon: '✍️', title: 'Verb Mastery', desc: 'Conjugation practice' },
     { icon: '📦', title: 'Anki Decks', desc: 'Custom flashcard exports' },

--- a/src/routes/password-reset/+page.svelte
+++ b/src/routes/password-reset/+page.svelte
@@ -72,7 +72,7 @@
 			<li>
 				<h2 class="text-xl font-semibold text-text-200">Sentence Practice</h2>
 				<p class="text-md text-text-200">
-					Practice reading comprehension and writing skills with AI generated short sentences.
+					Practice reading comprehension and writing skills with custom short sentences.
 				</p>
 			</li>
 			<li>

--- a/src/routes/password-reset/[token]/+page.svelte
+++ b/src/routes/password-reset/[token]/+page.svelte
@@ -79,7 +79,7 @@
 			<li>
 				<h2 class="text-xl font-semibold text-text-200">Sentence Practice</h2>
 				<p class="text-md text-text-200">
-					Practice reading comprehension and writing skills with AI generated short sentences.
+					Practice reading comprehension and writing skills with custom short sentences.
 				</p>
 			</li>
 			<li>

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -8,7 +8,7 @@
          <div class="max-w-4xl mx-auto">
             <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-text-300 mb-6 tracking-tight">Pricing</h1>
             <p class="text-xl text-text-200 max-w-2xl mx-auto leading-relaxed">
-                Master multiple Arabic dialects with AI-powered learning. All for the price of one lesson on
+                Master multiple Arabic dialects with personalized learning. All for the price of one lesson on
                 <a class="underline text-text-300 hover:text-tile-500 transition-colors" target="_blank" href="https://www.italki.com/en/teachers/arabic?from%5B0%5D=EG&speaks%5B0%5D=english">Italki</a> per month.
             </p>
         </div>
@@ -31,7 +31,7 @@
                             </li>
                             <li class="flex items-start gap-3">
                                 <div class="shrink-0 mt-1"><Checkmark /></div>
-                                <span>5 AI-generated practice sentences across multiple dialects <span class="text-text-200 text-sm italic">*requires account</span></span>
+                                <span>5 practice sentences across multiple dialects <span class="text-text-200 text-sm italic">*requires account</span></span>
                             </li>
                             <li class="flex items-start gap-3">
                                 <div class="shrink-0 mt-1"><Checkmark /></div>
@@ -103,7 +103,7 @@
                             </li>
                             <li class="flex items-start gap-3">
                                 <div class="shrink-0 mt-1"><Checkmark /></div>
-                                <span><strong class="text-text-300">Unlimited AI-generated practice sentences</strong> for all skill levels</span>
+                                <span><strong class="text-text-300">Unlimited sentence mining</strong> for all skill levels</span>
                             </li>
                              <li class="flex items-start gap-3">
                                 <div class="shrink-0 mt-1"><Checkmark /></div>

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -1077,7 +1077,7 @@
             <div class="text-5xl mb-6 transform group-hover:scale-125 group-hover:rotate-12 transition-transform duration-300 relative z-10">✍️</div>
             <h3 class="text-2xl font-bold text-text-300 mb-3 relative z-10">Generate Sentences</h3>
             <p class="text-text-200 leading-relaxed relative z-10">
-              Practice with AI-generated sentences focusing on specific grammar topics or vocabulary.
+              Practice with custom practice sentences focusing on specific grammar topics or vocabulary.
             </p>
           </button>
 

--- a/src/routes/review/import/+page.svelte
+++ b/src/routes/review/import/+page.svelte
@@ -247,7 +247,7 @@
             <p class="text-text-200 text-sm">
               Upload a CSV file with columns: arabic, english, transliteration (optional).
               Or upload an unstructured TXT file with Arabic text (one word or phrase per line).
-              Missing fields will be automatically generated using AI.
+              Missing fields will be filled in automatically.
             </p>
             
             <!-- Dialect Selection for CSV -->
@@ -334,13 +334,13 @@
               <p class="mb-1">• Required columns: <strong>arabic</strong> or <strong>english</strong></p>
               <p class="mb-1">• Optional columns: <strong>transliteration</strong></p>
               <p class="mb-1">• Column name variations are automatically detected</p>
-              <p class="mb-3">• Missing fields will be generated using AI</p>
+              <p class="mb-3">• Missing fields will be filled in automatically</p>
               
               <p class="font-medium text-text-300 mb-1">For TXT files:</p>
               <p class="mb-1">• One word or phrase per line</p>
               <p class="mb-1">• <strong class="text-red-400">Important:</strong> Lines without Arabic characters will be ignored</p>
               <p class="mb-1">• You can include English or transliteration on the same line (separated by comma, pipe, or semicolon)</p>
-              <p>• Missing fields (English, transliteration) will be generated using AI</p>
+              <p>• Missing fields (English, transliteration) will be filled in automatically</p>
             </div>
           </div>
         {:else}
@@ -348,7 +348,7 @@
           <div class="flex flex-col gap-4">
             <h2 class="text-2xl font-bold text-text-300">Paste Vocabulary</h2>
             <p class="text-text-200 text-sm">
-              Paste your vocabulary words below. Any missing fields (Arabic, English, or transliteration) will be automatically generated using AI.
+              Paste your vocabulary words below. Any missing fields (Arabic, English, or transliteration) will be filled in automatically.
             </p>
 
             <!-- Dialect Selection for Paste -->
@@ -378,10 +378,10 @@
 
             <div class="bg-tile-300/50 border border-tile-500 rounded-lg p-4 text-sm text-text-200">
               <p class="font-medium text-text-300 mb-2">Supported formats (one entry per line):</p>
-              <p class="mb-1">• <strong>Arabic only</strong> — AI generates English and transliteration</p>
-              <p class="mb-1">• <strong>English only</strong> — AI generates Arabic and transliteration</p>
+              <p class="mb-1">• <strong>Arabic only</strong> — English and transliteration filled in for you</p>
+              <p class="mb-1">• <strong>English only</strong> — Arabic and transliteration filled in for you</p>
               <p class="mb-1">• <strong>arabic | english | transliteration</strong> — all three fields</p>
-              <p class="mb-1">• <strong>arabic, english</strong> — AI generates transliteration</p>
+              <p class="mb-1">• <strong>arabic, english</strong> — transliteration filled in for you</p>
               <p>• Separators: comma <code class="bg-tile-400/50 px-1 rounded">,</code> pipe <code class="bg-tile-400/50 px-1 rounded">|</code> or semicolon <code class="bg-tile-400/50 px-1 rounded">;</code></p>
             </div>
           </div>

--- a/src/routes/self-study/+page.svelte
+++ b/src/routes/self-study/+page.svelte
@@ -140,7 +140,7 @@
                         rows="16"
                         class="w-full bg-tile-400 border-2 border-tile-600 rounded-xl p-4 text-base text-text-300 placeholder-text-200 focus:outline-none focus:border-blue-400 transition-colors resize-none font-mono leading-relaxed"
                     ></textarea>
-                    <p class="text-xs text-text-200">Any format works — the AI parses it.</p>
+                    <p class="text-xs text-text-200">Any format works — we'll handle the formatting.</p>
                 </div>
                 <div class="flex flex-col gap-2">
                     <label class="text-sm font-bold text-text-300" for="grammar-notes">

--- a/src/routes/sentences/+page.svelte
+++ b/src/routes/sentences/+page.svelte
@@ -425,7 +425,7 @@
 				Sentence Practice
 			</h1>
 			<p class="text-text-200 text-base sm:text-lg leading-snug max-w-2xl">
-				Drill grammar patterns and vocabulary in context with unlimited AI-generated sentences.
+				Drill grammar patterns and vocabulary in context with unlimited custom practice sentences.
 			</p>
 		</div>
 	</header>

--- a/src/routes/signup/+page.svelte
+++ b/src/routes/signup/+page.svelte
@@ -78,7 +78,7 @@
     { icon: '📖', title: 'Stories & Audio', desc: 'Native audio pronunciation' },
     { icon: '💬', title: 'AI Tutor', desc: 'Real-time conversation practice' },
     { icon: '📺', title: 'Interactive Videos', desc: 'YouTube with transcripts' },
-    { icon: '🤖', title: 'AI Practice', desc: 'Unlimited generated sentences' },
+    { icon: '✨', title: 'Sentence Mining', desc: 'Unlimited practice sentences' },
     { icon: '🎙️', title: 'Speaking', desc: 'Pronunciation feedback' },
     { icon: '✍️', title: 'Verb Mastery', desc: 'Conjugation practice' },
     { icon: '📦', title: 'Anki Decks', desc: 'Custom flashcard exports' },

--- a/src/routes/speak/+page.svelte
+++ b/src/routes/speak/+page.svelte
@@ -411,7 +411,7 @@
 					<div class="min-w-0">
 						<h1 class="text-2xl sm:text-3xl font-bold text-text-300 tracking-tight">Speaking Practice</h1>
 						<p class="text-text-200 text-sm sm:text-base leading-snug mt-1 max-w-2xl">
-							Practice your Arabic pronunciation with AI-generated sentences and get real-time feedback.
+							Practice your Arabic pronunciation with custom practice sentences and get real-time feedback.
 						</p>
 					</div>
 				</div>
@@ -702,8 +702,8 @@
 				<h2 class="text-xl sm:text-2xl font-bold text-text-300 text-center mb-6">How It Works</h2>
 				<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
 					<div class="bg-tile-400 border border-tile-500 rounded-xl p-4 shadow-sm text-center">
-						<div class="text-3xl mb-3">🤖</div>
-						<h3 class="text-lg font-bold text-text-300 mb-2">AI-Generated</h3>
+						<div class="text-3xl mb-3">✨</div>
+						<h3 class="text-lg font-bold text-text-300 mb-2">Sentence Mining</h3>
 						<p class="text-text-200 leading-relaxed">
 							Personalized sentences based on your level and chosen topics.
 						</p>

--- a/src/routes/videos/+page.svelte
+++ b/src/routes/videos/+page.svelte
@@ -229,7 +229,7 @@
 					<div class="text-4xl mb-4">📖</div>
 					<h3 class="text-xl font-bold text-text-300 mb-3">Instant Definitions</h3>
 					<p class="text-text-200 leading-relaxed">
-						Click any word in the transcript to get AI-powered definitions and explanations instantly.
+						Click any word in the transcript to get instant definitions and explanations.
 					</p>
 				</div>
 


### PR DESCRIPTION
## Summary

Removes user-facing "AI" references from product copy — users don't respond well to the term. Generated features are reframed in human/teacher language, and practice sentences are rebranded as **"sentence mining"** (a known language-learning concept). All changes are copy-only (55 line swaps across 31 files, no logic touched).

## What changed

- **Practice sentences → "sentence mining"** — signup/login cards, pricing, PaywallModal, email, speak/sentences/review pages (🤖 → ✨ where paired).
- **Lessons / stories / content → "custom" / "personalized"** — lessons, about, FAQ, CreateLessonModal/CreateStoryModal (incl. "✨ AI Generate" → "✨ Create").
- **Definitions** → "instant definitions and explanations".
- **Import flow** → "filled in automatically / for you" instead of "generated using AI".
- **Error messages** → "The AI model is currently overloaded…" → "Our service is experiencing high demand…" across 11 API endpoints; "AI Response Format Error" → "Content Format Error".

## Kept as-is (intentional)

- **All AI Tutor copy** — tutor page, explore, SEO, email, home tile, onboarding, "AI Tutor" feature cards, FAQ tutor lines.
- The About-page testimonial quoting "your AI".
- Internal code — `ai`/`GoogleGenAI` variables, comments, model system-prompts.

## Verification

`npm run check` shows only pre-existing type errors (unrelated line numbers); every change is string-content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)