### PR TITLE
Redirect entire /alphabet section to /alphabet-new

### DIFF
--- a/src/routes/alphabet/+layout.ts
+++ b/src/routes/alphabet/+layout.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+
+// The whole /alphabet section (index, learn, practice, ...) now lives at /alphabet-new.
+export const load = () => {
+	redirect(307, '/alphabet-new');
+};


### PR DESCRIPTION
## Summary
Adds `src/routes/alphabet/+layout.ts` with a 307 redirect to `/alphabet-new`. Because it's a layout load, it covers the index **and every child route** under `/alphabet`:

- `/alphabet`
- `/alphabet/learn`
- `/alphabet/practice`
- `/alphabet/practice/keyboard`
- `/alphabet/practice/handwriting`

This generalizes the per-page redirect from #173 so anything under the old `/alphabet` route lands on `/alphabet-new`.

## Notes
- **Stacked on #173** (base branch `feat/alphabet-new-card-view-and-exercises`), since the redirect target `/alphabet-new` lives there. Retarget to `master` once #173 merges.
- The `/alphabet/+page.ts` redirect from #173 is now redundant (the layout handles the index) but left in place; both point to the same target.
- `/alphabet-new` is a sibling route, not under `/alphabet`, so there's no redirect loop.

## Test plan
- [ ] Visiting `/alphabet/learn` redirects to `/alphabet-new`
- [ ] `/alphabet/practice`, `/alphabet/practice/keyboard`, `/alphabet/practice/handwriting` all redirect
- [ ] `/alphabet` index still redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)