### PR TITLE
Scenario Learn phase + tutor level calibration

### DIFF
--- a/src/lib/components/AuthModal.svelte
+++ b/src/lib/components/AuthModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Modal from '$lib/components/Modal.svelte';
   import Button from '$lib/components/Button.svelte';
+  import Testimonial from '$lib/components/Testimonial.svelte';
   import { goto } from '$app/navigation';
 
   type Props = {
@@ -31,6 +32,12 @@
                 Create an account or log in to continue your learning journey.
             </p>
         </div>
+        <Testimonial
+            class="mt-6"
+            segments={[
+                { t: 'This is great! As someone outgrowing Duolingo this is perfect.', b: true }
+            ]}
+        />
     </div>
 
     <!-- Footer / Action -->

--- a/src/lib/components/MobileMenu.svelte
+++ b/src/lib/components/MobileMenu.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { fly, fade } from 'svelte/transition';
+
+  interface NavItem {
+    label: string;
+    href: string;
+    icon: string;
+  }
+
+  interface NavSection {
+    title: string;
+    items: NavItem[];
+  }
+
+  interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+    session: any;
+    handleOpenDrawer?: () => void;
+  }
+
+  let { isOpen, onClose, session, handleOpenDrawer }: Props = $props();
+
+  const navSections = $derived.by(() => {
+    const baseSections: NavSection[] = [
+      {
+        title: 'Learn',
+        items: [
+          { label: 'Alphabet', href: '/alphabet', icon: '✍️' },
+          { label: 'Lessons', href: '/lessons', icon: '📚' },
+          { label: 'Vocab Review', href: '/review', icon: '🧠' },
+        ]
+      },
+      {
+        title: 'Practice',
+        items: [
+          { label: 'Game', href: '/learn/game', icon: '🎮' },
+          { label: 'Sentences', href: '/sentences', icon: '📝' },
+          { label: 'Conjugations', href: '/conjugations', icon: '🔄' },
+          { label: 'Stories', href: '/stories', icon: '📖' },
+          { label: 'Speak', href: '/speak', icon: '🎤' },
+          { label: 'Tutor', href: '/tutor', icon: '💬' },
+        ]
+      },
+      {
+        title: 'General',
+        items: [
+          { label: 'My words', href: '/review/all-words', icon: '🗂️' },
+          { label: 'History', href: '/history', icon: '📜' },
+          session
+            ? { label: 'Profile', href: '/profile', icon: '👤' }
+            : { label: 'Login', href: '/login', icon: '🔐' }
+        ]
+      }
+    ];
+    return baseSections;
+  });
+
+  function isActive(href: string): boolean {
+    const currentPath = $page.url.pathname;
+    if (href === '/') {
+      return currentPath === '/';
+    }
+    return currentPath.startsWith(href);
+  }
+
+  function handleThemeClick() {
+    onClose();
+    handleOpenDrawer?.();
+  }
+</script>
+
+{#if isOpen}
+  <!-- Backdrop -->
+  <button
+    type="button"
+    aria-label="Close menu"
+    class="fixed inset-0 z-[60] bg-black/40 lg:hidden"
+    transition:fade={{ duration: 200 }}
+    onclick={onClose}
+  ></button>
+
+  <!-- Slide-in panel -->
+  <aside
+    class="fixed left-0 top-0 bottom-0 z-[70] flex w-72 max-w-[85vw] flex-col bg-gradient-to-b from-tile-300 via-tile-300 to-tile-200 border-r border-tile-500 shadow-2xl lg:hidden"
+    transition:fly={{ x: -288, duration: 250 }}
+  >
+    <!-- Header -->
+    <div class="flex items-center gap-2 px-4 pt-5 pb-4">
+      <a href="/" onclick={onClose} class="group flex min-w-0 flex-1 items-center gap-2.5">
+        <span class="truncate text-lg font-bold tracking-tight text-text-300 transition-colors duration-200 group-hover:text-brand">
+          Home
+        </span>
+      </a>
+      <button
+        type="button"
+        onclick={onClose}
+        class="grid h-9 w-9 flex-shrink-0 place-items-center rounded-lg text-text-200 transition-all duration-200 hover:bg-tile-400 hover:text-text-300 active:scale-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300"
+        aria-label="Close menu"
+        title="Close menu"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      </button>
+    </div>
+
+    <div class="mx-4 h-px bg-tile-500/70"></div>
+
+    <!-- Scrollable navigation -->
+    <nav class="flex-1 overflow-y-auto px-3 py-4">
+      {#each navSections as section (section.title)}
+        <div class="mb-3">
+          <p class="px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-text-200">
+            {section.title}
+          </p>
+
+          <div class="mt-1.5 flex flex-col gap-0.5">
+            {#each section.items as item (item.href)}
+              {@const active = isActive(item.href)}
+              <a
+                href={item.href}
+                onclick={onClose}
+                aria-current={active ? 'page' : undefined}
+                class="group relative flex items-center gap-3 rounded-lg py-2 pl-4 pr-3 transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:[outline-offset:-2px] focus-visible:outline-text-300 {active
+                  ? 'bg-tile-400 font-semibold text-text-300 shadow-sm'
+                  : 'text-text-200 hover:bg-tile-400 hover:text-text-300'}"
+              >
+                <!-- Active indicator pill -->
+                <span
+                  aria-hidden="true"
+                  class="absolute left-0 top-1/2 w-[3px] -translate-y-1/2 rounded-r-full bg-brand transition-all duration-300 ease-out {active ? 'h-6 opacity-100' : 'h-0 opacity-0'}"
+                ></span>
+
+                <span
+                  class="grid h-7 w-7 flex-shrink-0 place-items-center rounded-md text-[15px] leading-none transition-all duration-200 {active
+                    ? 'scale-105 bg-tile-200 shadow-sm'
+                    : 'bg-transparent group-hover:bg-tile-300'}"
+                >
+                  {item.icon}
+                </span>
+                <span class="text-sm">{item.label}</span>
+              </a>
+            {/each}
+          </div>
+        </div>
+      {/each}
+    </nav>
+
+    <!-- Theme Toggle -->
+    {#if handleOpenDrawer}
+      <div class="border-t border-tile-500 p-3">
+        <button
+          type="button"
+          onclick={handleThemeClick}
+          class="group flex w-full items-center gap-3 rounded-lg py-2 pl-4 pr-3 text-text-200 transition-all duration-200 hover:bg-tile-400 hover:text-text-300 focus-visible:outline focus-visible:outline-2 focus-visible:[outline-offset:-2px] focus-visible:outline-text-300"
+        >
+          <span class="grid h-7 w-7 flex-shrink-0 place-items-center rounded-md text-[15px] leading-none transition-all duration-200 group-hover:bg-tile-300">
+            🎨
+          </span>
+          <span class="text-sm font-medium">Theme</span>
+        </button>
+      </div>
+    {/if}
+  </aside>
+{/if}
+
+<style>
+  aside {
+    scrollbar-width: thin;
+    scrollbar-color: var(--tile6) transparent;
+  }
+
+  nav::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  nav::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  nav::-webkit-scrollbar-thumb {
+    background: var(--tile5);
+    border-radius: 3px;
+  }
+
+  nav::-webkit-scrollbar-thumb:hover {
+    background: var(--tile6);
+  }
+</style>

--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Button from "./Button.svelte";
+  import MobileMenu from "./MobileMenu.svelte";
 
   interface Props {
     handleOpenDrawer: () => void;
@@ -13,6 +14,8 @@
   }
 
   let { handleOpenDrawer, session, targetDialect, user }: Props = $props();
+
+  let mobileMenuOpen = $state(false);
 
   // Map dialect values to flags (default to Egyptian)
   const dialectFlags: Record<string, string> = {
@@ -42,9 +45,17 @@
 <nav class="w-full border-b border-tile-600 py-4 bg-gradient-to-b from-tile-300 to-tile-200 backdrop-blur-sm sticky top-0 z-50 shadow-md">
     <menu class="w-full flex gap-4 px-4 sm:px-6 items-center flex-wrap">
         <li>
-          <a class="text-text-200 hover:text-text-300 text-sm sm:text-base font-semibold transition-colors duration-200" href="/">
-            Home
-          </a>
+          <button
+            type="button"
+            onclick={() => (mobileMenuOpen = true)}
+            class="grid h-9 w-9 place-items-center rounded-lg text-text-200 transition-all duration-200 hover:bg-tile-400 hover:text-text-300 active:scale-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300"
+            aria-label="Open menu"
+            title="Open menu"
+          >
+            <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+          </button>
         </li>
         <menu class="ml-auto flex flex-row gap-3 sm:gap-4 items-center">
           {#if session}
@@ -81,3 +92,10 @@
         </menu>
     </menu>
 </nav>
+
+<MobileMenu
+  isOpen={mobileMenuOpen}
+  onClose={() => (mobileMenuOpen = false)}
+  {session}
+  {handleOpenDrawer}
+/>

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -532,7 +532,7 @@
                     icon: '✍️',
                     title: 'Alphabet',
                     description: 'Learn to read Arabic script from scratch',
-                    url: '/alphabet/learn',
+                    url: '/alphabet-new',
                     badge: proficiencyLevel === 'A1' || proficiencyLevel === 'A2' ? 'New to Arabic script?' : null
                   },
                   {

--- a/src/lib/components/PaywallModal.svelte
+++ b/src/lib/components/PaywallModal.svelte
@@ -2,6 +2,7 @@
   import Modal from '$lib/components/Modal.svelte';
   import Checkmark from '$lib/components/Checkmark.svelte';
   import SubscribeButton from '$lib/components/SubscribeButton.svelte';
+  import Testimonial from '$lib/components/Testimonial.svelte';
 
   type Props = {
     isOpen: boolean;
@@ -64,6 +65,14 @@
 
     <!-- Footer / Action -->
     <div class="p-6 pt-0">
+      <Testimonial
+        class="mb-4"
+        segments={[
+          { t: "Have tried many of the 'apps' and " },
+          { t: 'this is the closest one to doing what I want!', b: true },
+          { t: ' Very useful and comprehensive — I love the interlinear format for the stories.' }
+        ]}
+      />
       <SubscribeButton className="!py-3 !text-lg w-full shadow-md" />
       <p class="mt-3 text-xs text-text-200 text-center">
         By subscribing you agree to our

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -71,6 +71,7 @@
         title: 'General',
         items: [
           { label: 'My words', href: '/review/all-words', icon: '🗂️' },
+          { label: 'History', href: '/history', icon: '📜' },
           session
             ? { label: 'Profile', href: '/profile', icon: '👤' }
             : { label: 'Login', href: '/login', icon: '🔐' }

--- a/src/lib/components/Testimonial.svelte
+++ b/src/lib/components/Testimonial.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  type Segment = { t: string; b?: boolean };
+
+  let {
+    segments,
+    class: className = ''
+  }: { segments: Segment[]; class?: string } = $props();
+</script>
+
+<figure
+  class="relative overflow-hidden rounded-xl border border-tile-500 bg-gradient-to-br from-tile-300/80 to-tile-400/40 p-5 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md {className}"
+>
+  <span
+    class="pointer-events-none absolute -right-1 -top-4 select-none font-serif text-7xl leading-none text-tile-500/50"
+    aria-hidden="true">”</span>
+  <div class="mb-2 flex gap-0.5" aria-label="Rated 5 out of 5 stars">
+    {#each [0, 1, 2, 3, 4] as i (i)}
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="#f59e0b" aria-hidden="true">
+        <path d="M12 2l2.9 6.26L21.5 9.27l-4.75 4.64L17.9 21 12 17.27 6.1 21l1.15-7.09L2.5 9.27l6.6-1.01z" />
+      </svg>
+    {/each}
+  </div>
+  <blockquote class="relative text-sm leading-relaxed text-text-200">
+    {#each segments as seg, i (i)}{#if seg.b}<strong class="text-text-300">{seg.t}</strong>{:else}{seg.t}{/if}{/each}
+  </blockquote>
+</figure>

--- a/src/lib/utils/gemini-schemas.ts
+++ b/src/lib/utils/gemini-schemas.ts
@@ -162,6 +162,34 @@ export function createWordsSchema() {
 export type WordsSchema = z.infer<ReturnType<typeof createWordsSchema>['zodSchema']>;
 
 /**
+ * Schema for scenario intro vocab (Learn phase before a guided conversation).
+ * Returns key beginner words/phrases plus a few short practice sentences that
+ * build on those words. Each item carries a short, friendly teaching line the
+ * tutor would say out loud (e.g. "The word for 'my name' is 'ismi'").
+ * Kept deliberately flat/simple to avoid Gemini 400s on complex schemas.
+ */
+export function createScenarioVocabSchema() {
+	const learnItem = z.object({
+		arabic: z.string(),
+		transliteration: z.string(),
+		english: z.string(),
+		teachingLine: z.string()
+	});
+
+	const schema = z.object({
+		vocab: z.array(learnItem),
+		sentences: z.array(learnItem)
+	});
+
+	return {
+		zodSchema: schema,
+		jsonSchema: zodToJsonSchema(schema)
+	};
+}
+
+export type ScenarioVocabSchema = z.infer<ReturnType<typeof createScenarioVocabSchema>['zodSchema']>;
+
+/**
  * Schema for tutor chat / translation responses
  */
 export function createTranslationResponseSchema() {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,6 @@
 	// Critical components - needed for initial render
 	import Navigation from '$lib/components/Navigation.svelte';
 	import Sidebar from '$lib/components/Sidebar.svelte';
-	import BottomNavigation from '$lib/components/BottomNavigation.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 
 	import { onMount } from 'svelte';
@@ -497,7 +496,7 @@
 
 <!-- Main Content Area -->
 <main
-	class="flex min-h-screen flex-col bg-tile-200 pb-20 transition-all duration-300 lg:pb-0 {$sidebarCollapsed
+	class="flex min-h-screen flex-col bg-tile-200 transition-all duration-300 {$sidebarCollapsed
 		? 'lg:ml-0'
 		: 'lg:ml-64'} {data.session ? 'lg:pt-8' : ''}"
 >
@@ -520,9 +519,6 @@
 	<!-- Footer -->
 	<Footer />
 </main>
-
-<!-- Bottom Navigation - Mobile only -->
-<BottomNavigation />
 
 <!-- Chat Widget - lazy loaded, only shows on desktop -->
 {#if ChatWidget}

--- a/src/routes/api/scenario-intro/+server.ts
+++ b/src/routes/api/scenario-intro/+server.ts
@@ -1,0 +1,116 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/private';
+import { GoogleGenAI } from '@google/genai';
+import { type Dialect } from '$lib/types/index';
+import { parseJsonFromGeminiResponse } from '$lib/utils/gemini-json-parser';
+import { createScenarioVocabSchema } from '$lib/utils/gemini-schemas';
+import { generateContentWithRetry, GeminiApiError } from '$lib/utils/gemini-api-retry';
+
+type ScenarioLine = {
+  speaker: 'student' | 'other';
+  arabic: string;
+  transliteration: string;
+  english: string;
+};
+
+const dialectNames: Record<Dialect, string> = {
+  fusha: 'Modern Standard Arabic (Fusha)',
+  levantine: 'Levantine Arabic',
+  darija: 'Moroccan Darija',
+  'egyptian-arabic': 'Egyptian Arabic',
+  iraqi: 'Iraqi Arabic',
+  khaleeji: 'Khaleeji Arabic'
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+  try {
+    const apiKey = env['GEMINI_API_KEY'];
+    if (!apiKey) {
+      return error(500, { message: 'GEMINI_API_KEY is not configured' });
+    }
+
+    const { dialect, scenarioTitle, scenarioDescription, lines, proficiencyLevel } =
+      await request.json();
+
+    if (!dialect || !dialectNames[dialect as Dialect]) {
+      return error(400, { message: 'Invalid dialect' });
+    }
+
+    const ai = new GoogleGenAI({ apiKey });
+    const dialectName = dialectNames[dialect as Dialect];
+    const level =
+      typeof proficiencyLevel === 'string' && proficiencyLevel.trim()
+        ? proficiencyLevel.trim()
+        : 'A1';
+
+    const scenarioLines: ScenarioLine[] = Array.isArray(lines) ? lines : [];
+    const dialogText = scenarioLines.length
+      ? scenarioLines
+          .map((l) => `${l.speaker === 'student' ? 'Student' : 'Other'}: ${l.arabic} (${l.english})`)
+          .join('\n')
+      : '(no sample dialog provided)';
+
+    const { zodSchema, jsonSchema } = createScenarioVocabSchema();
+
+    const prompt = `You are an Arabic tutor preparing a beginner for a short roleplay conversation.
+
+SCENARIO: "${scenarioTitle}"${scenarioDescription ? ` — ${scenarioDescription}` : ''}
+Target dialect: ${dialectName}.
+Student's proficiency level: ${level} (CEFR).
+
+Here is the sample dialog the conversation is based on:
+${dialogText}
+
+Produce two things:
+
+1. "vocab": the 6 to 9 MOST important words or short phrases the student will need to take part in this conversation. Favour the words the student themselves will say.
+
+2. "sentences": 3 to 4 short, natural full sentences that BUILD ON the vocab above — each sentence should reuse one or more of the vocab words so the student practises them in context. Keep them beginner-appropriate for level ${level}.
+
+For EVERY item (in both lists) provide:
+- "arabic": the word/phrase/sentence in ${dialectName} (beginner-appropriate).
+- "transliteration": Latin-letter transliteration.
+- "english": the English meaning.
+- "teachingLine": one short, warm sentence a tutor would say out loud to introduce it. For vocab, name the English meaning and the transliteration, e.g. "The word for 'my name' is 'ismi'." For sentences, e.g. "Now try a full sentence: 'ana ismi Sara' — 'My name is Sara'." One sentence, no quotes around the whole line.
+
+Respond as JSON with this exact shape:
+{
+  "vocab": [
+    { "arabic": "...", "transliteration": "...", "english": "...", "teachingLine": "..." }
+  ],
+  "sentences": [
+    { "arabic": "...", "transliteration": "...", "english": "...", "teachingLine": "..." }
+  ]
+}`;
+
+    const response = await generateContentWithRetry(ai, {
+      model: 'gemini-2.5-flash',
+      contents: prompt,
+      config: {
+        temperature: 0.6,
+        maxOutputTokens: 4096,
+        // Disable thinking — gemini-2.5-flash's thinking tokens count against
+        // maxOutputTokens and can leave no room for the actual JSON output.
+        thinkingConfig: { thinkingBudget: 0 },
+        responseMimeType: 'application/json',
+        responseJsonSchema: jsonSchema
+      }
+    });
+
+    const responseContent = response.text;
+    if (!responseContent) {
+      throw new Error('No response from Gemini');
+    }
+
+    const parsed = parseJsonFromGeminiResponse(responseContent, zodSchema);
+
+    return json({ vocab: parsed.vocab, sentences: parsed.sentences });
+  } catch (e) {
+    console.error('Scenario intro error:', e);
+    if (e instanceof GeminiApiError && e.is503) {
+      return error(503, { message: 'Our service is currently busy. Please try again.' });
+    }
+    return error(500, { message: 'Failed to generate scenario vocab.' });
+  }
+};

--- a/src/routes/api/tutor-chat/+server.ts
+++ b/src/routes/api/tutor-chat/+server.ts
@@ -27,6 +27,35 @@ const dialectNames: Record<Dialect, string> = {
   'khaleeji': 'Khaleeji Arabic'
 };
 
+type CefrLevel = 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2';
+
+// Normalize whatever the profile stores ("A1", "beginner", "Upper Int.", …) to a
+// CEFR level so we can calibrate response length/complexity to the learner.
+function normalizeCefrLevel(input?: string | null): CefrLevel {
+  const s = (input || '').toUpperCase();
+  const m = s.match(/[ABC][12]/);
+  if (m) return m[0] as CefrLevel;
+  if (s.includes('BEGIN')) return 'A1';
+  if (s.includes('ELEMENT')) return 'A2';
+  if (s.includes('UPPER')) return 'B2';
+  if (s.includes('INTER')) return 'B1';
+  if (s.includes('ADVAN')) return 'C1';
+  if (s.includes('PROFIC') || s.includes('FLUENT') || s.includes('MASTER')) return 'C2';
+  return 'A1';
+}
+
+// Per-level response calibration. This is the single most important control on
+// tutor output: responses must match the learner's level — short/simple for A1,
+// progressively longer/richer toward C2.
+const LEVEL_GUIDANCE: Record<CefrLevel, string> = {
+  A1: 'Reply with ONE very short sentence (about 4–8 words). Use only the most common, basic everyday words and simple present tense. No idioms, no subordinate clauses. Be as simple as possible.',
+  A2: 'Reply with 1–2 short, simple sentences. Use common everyday vocabulary and basic past/present tense. Keep grammar simple and avoid idioms.',
+  B1: 'Reply with 2–3 sentences. You may introduce some new vocabulary when context makes it clear. Use common connectors and a mix of tenses.',
+  B2: 'Reply with 3–4 sentences. Use richer, more varied vocabulary, a range of tenses, and the occasional idiom. You can touch on more abstract topics.',
+  C1: 'Reply with 4–5 sentences of natural, near-native speech. Use nuanced vocabulary, idioms, and cultural references freely.',
+  C2: 'Reply naturally as you would with a fluent native speaker — full complexity, nuance, idioms and sophisticated vocabulary, at whatever length fits the conversation.'
+};
+
 export const POST: RequestHandler = async ({ request, locals }) => {
   try {
     const apiKey = env['GEMINI_API_KEY'];
@@ -35,7 +64,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     }
     
     const ai = new GoogleGenAI({ apiKey });
-    const { message, dialect, conversation, conversationId: clientConversationId } = await request.json();
+    const { message, dialect, conversation, conversationId: clientConversationId, proficiencyLevel: clientProficiencyLevel } = await request.json();
 
     if (!message || typeof message !== 'string') {
       return error(400, { message: 'Invalid message format' });
@@ -53,7 +82,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     // Build learner context if user is logged in
     let learnerContextString = '';
     let conversationId = clientConversationId;
-    
+    // Effective level: client-provided wins, then the stored profile, then A1.
+    let level: CefrLevel = normalizeCefrLevel(clientProficiencyLevel);
+
     if (userId) {
       try {
         // Build learner context and get/create conversation in parallel
@@ -63,6 +94,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
         ]);
         learnerContextString = formatLearnerContextForPrompt(learnerContext);
         conversationId = resolvedId;
+        if (!clientProficiencyLevel && learnerContext.profile.proficiency_level) {
+          level = normalizeCefrLevel(learnerContext.profile.proficiency_level);
+        }
 
         // Save user message without blocking the Gemini call
         saveMessage(conversationId, 'user', null, message, null, null).catch(e =>
@@ -81,6 +115,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     
     // Build adaptive system prompt with learner context
     const systemPrompt = `You are a friendly, patient, and encouraging Arabic tutor specializing in ${dialectName}. You're having a natural conversation with a student learning Arabic.
+
+=== RESPONSE LEVEL — MOST IMPORTANT RULE ===
+The student's level is ${level} (CEFR). Calibrate EVERY response to this level:
+${LEVEL_GUIDANCE[level]}
+This overrides any other guidance about length. A reply that is too long, or uses vocabulary/grammar above ${level}, is a failure even if otherwise correct. Stay at or just slightly above the student's level so they can follow and learn.
+=== END RESPONSE LEVEL ===
 
 ${learnerContextString ? `
 === PERSONALIZED CONTEXT ===
@@ -102,7 +142,7 @@ IMPORTANT GUIDELINES:
 - When translating English phrases to Arabic, provide the translation in ${dialectName}
 - Keep responses conversational, natural, and appropriate for language learners
 - Be encouraging and supportive - celebrate progress!
-- Keep responses concise (1-3 sentences typically) unless explaining something complex
+- Match response length and complexity to the RESPONSE LEVEL rule above — this is the authority on how long/complex your reply should be
 - Use vocabulary appropriate for the student's level based on the conversation and their profile
 - If the student makes mistakes, gently correct them in a helpful way
 - Ask follow-up questions to keep the conversation going
@@ -151,8 +191,13 @@ IMPORTANT: wordAlignments must have one entry per Arabic word in your response, 
       contents: fullPrompt,
       config: {
         temperature: 0.8, // Slightly higher for more natural conversation
-        maxOutputTokens: 2048,
+        maxOutputTokens: 4096,
         topP: 0.9,
+        // gemini-2.5-flash "thinks" by default and thinking tokens count against
+        // maxOutputTokens. With this heavy prompt the model could spend the whole
+        // budget thinking and return no text (finishReason MAX_TOKENS), surfacing
+        // as "No response from Gemini". We don't need reasoning for this JSON reply.
+        thinkingConfig: { thinkingBudget: 0 },
         responseMimeType: 'application/json',
         responseJsonSchema: translationSchema.jsonSchema
       }

--- a/src/routes/api/tutor-hint/+server.ts
+++ b/src/routes/api/tutor-hint/+server.ts
@@ -67,14 +67,20 @@ Student's proficiency level: ${level} (CEFR). Calibrate vocabulary and sentence 
 Recent conversation so far:
 ${conversationContext}
 
-Generate the NEXT line the student could naturally say to continue the conversation, based on what ${speakerLabel} just said.
+Generate the NEXT line the student could naturally say, based on what ${speakerLabel} just said. The MOST IMPORTANT goal: the line must KEEP THE CONVERSATION GOING and give ${speakerLabel} a clear reason to reply.
+
+To keep it going, the line should do at least one of these:
+- ask ${speakerLabel} a relevant question back,
+- share a new detail about the student that invites a follow-up, or
+- open a natural next sub-topic that fits the scenario.
 
 Rules:
-- ONE short sentence in ${dialectName}, calibrated to level ${level}.
 - Sound natural, not robotic. Use everyday phrasing for ${dialectName}.
-- Do NOT repeat lines the student has already said.
+- Do NOT produce dead-end / closing lines like "Thanks", "I'm good", "Okay", or goodbyes — UNLESS the conversation is genuinely meant to wrap up.
+- Stay on-topic${scenarioTitle ? ` and move toward the goal of the scenario ("${scenarioTitle}")` : ''}.
+- Do NOT repeat lines the student has already said, and don't just echo ${speakerLabel}'s question back unchanged.
 - If a name or place would be needed, leave a "___" blank for the student to fill in.
-- For A1/A2 keep it very short (3-7 words). For B1+ a fuller sentence is okay.
+- Calibrate to level ${level}: for A1/A2 keep it short (3-8 words) but still open-ended — usually a short question works best. For B1+ a fuller sentence with a follow-up is great.
 
 Respond as JSON with this exact shape:
 {
@@ -91,6 +97,9 @@ Respond as JSON with this exact shape:
       config: {
         temperature: 0.7,
         maxOutputTokens: 1024,
+        // Disable thinking — gemini-2.5-flash's thinking tokens count against
+        // maxOutputTokens and can leave no room for the actual JSON output.
+        thinkingConfig: { thinkingBudget: 0 },
         responseMimeType: 'application/json',
         responseJsonSchema: schemaJson
       }

--- a/src/routes/history/+page.server.ts
+++ b/src/routes/history/+page.server.ts
@@ -1,0 +1,304 @@
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+import { supabase } from '$lib/supabaseClient';
+import { curriculum } from '$lib/data/curriculum';
+
+// A single, normalized entry in the activity history.
+export interface HistoryItem {
+	id: string;
+	type: 'story' | 'tutor' | 'lesson' | 'game' | 'review' | 'sentences';
+	icon: string;
+	title: string;
+	subtitle: string;
+	timestamp: number; // milliseconds
+	href: string;
+	status?: string;
+}
+
+interface HistoryDay {
+	dayKey: string;
+	dayLabel: string;
+	items: HistoryItem[];
+}
+
+const DIALECT_LABELS: Record<string, string> = {
+	'egyptian-arabic': 'Egyptian',
+	fusha: 'Fusha',
+	levantine: 'Levantine',
+	darija: 'Darija',
+	alphabet: 'Alphabet'
+};
+
+const dialectLabel = (d: string | null | undefined) => DIALECT_LABELS[d ?? ''] ?? (d ?? '');
+
+// Build topic_id -> title lookup once from the curriculum.
+const topicTitles: Record<string, string> = (() => {
+	const map: Record<string, string> = {};
+	for (const module of curriculum) {
+		for (const topic of module.topics) {
+			map[topic.id] = topic.title;
+		}
+	}
+	return map;
+})();
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Generated stories (UUID ids) live at /generated_story/{id}; hardcoded stories
+// (slug ids) live at /stories/{slug}.
+function storyHref(storyId: string): string {
+	return UUID_RE.test(storyId) ? `/generated_story/${storyId}` : `/stories/${storyId}`;
+}
+
+function prettifySlug(slug: string): string {
+	return slug
+		.replace(/[-_]+/g, ' ')
+		.replace(/\b\w/g, (c) => c.toUpperCase())
+		.trim();
+}
+
+// Local midnight key + friendly label for grouping.
+function dayKeyFor(ts: number): string {
+	const d = new Date(ts);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${day}`;
+}
+
+function dayLabelFor(ts: number): string {
+	const d = new Date(ts);
+	const today = new Date();
+	const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+	const diffDays = Math.round((startOf(today) - startOf(d)) / 86_400_000);
+	if (diffDays === 0) return 'Today';
+	if (diffDays === 1) return 'Yesterday';
+	return d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+export const load: PageServerLoad = async ({ parent }) => {
+	const { session, user } = await parent();
+
+	if (!session || !user) {
+		throw redirect(302, '/login');
+	}
+
+	const userId = user.id;
+	const WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+	const sinceMs = Date.now() - WINDOW_MS;
+	const sinceSec = Math.floor(sinceMs / 1000);
+
+	const [
+		generatedStories,
+		storyCompletions,
+		tutorConversations,
+		lessonProgress,
+		gameProgress,
+		dailyActivity
+	] = await Promise.all([
+		supabase
+			.from('generated_story')
+			.select('id, title, description')
+			.eq('user_id', userId)
+			.order('created_at', { ascending: false })
+			.limit(50),
+		supabase
+			.from('user_story_completion')
+			.select('story_id, completed_at')
+			.eq('user_id', userId)
+			.gte('completed_at', sinceMs)
+			.order('completed_at', { ascending: false })
+			.limit(100),
+		supabase
+			.from('tutor_conversation')
+			.select('id, dialect, created_at, summary, topics_discussed')
+			.eq('user_id', userId)
+			.gte('created_at', sinceMs)
+			.order('created_at', { ascending: false })
+			.limit(50),
+		supabase
+			.from('structured_lesson_progress')
+			.select('topic_id, dialect, status, started_at, completed_at, last_accessed_at')
+			.eq('user_id', userId)
+			.gte('last_accessed_at', sinceSec)
+			.order('last_accessed_at', { ascending: false })
+			.limit(100),
+		supabase
+			.from('game_progress')
+			.select('id, dialect, category, game_mode, status, score, total_questions, last_played_at')
+			.eq('user_id', userId)
+			.gte('last_played_at', sinceMs)
+			.order('last_played_at', { ascending: false })
+			.limit(100),
+		supabase
+			.from('user_daily_activity')
+			.select('activity_date, reviews_count, sentences_viewed')
+			.eq('user_id', userId)
+			.gte('activity_date', sinceMs)
+			.order('activity_date', { ascending: false })
+			.limit(60)
+	]);
+
+	const items: HistoryItem[] = [];
+
+	// Map of generated-story id -> title, used to label completions of own stories.
+	const generatedTitles: Record<string, string> = {};
+	// Daily-challenge stories are auto-generated and excluded from history.
+	const dailyChallengeStoryIds = new Set<string>();
+
+	const isDailyChallengeStory = (row: { title?: string | null; description?: string | null }) =>
+		row.description === 'Daily Challenge Story' || (row.title ?? '').startsWith('daily-challenge-');
+
+	// We don't surface "created" stories — only completions below. We still scan
+	// the user's generated stories to resolve completion titles and to identify
+	// auto-generated daily-challenge stories that should be excluded.
+	for (const row of generatedStories.data ?? []) {
+		if (isDailyChallengeStory(row)) {
+			dailyChallengeStoryIds.add(row.id);
+			continue;
+		}
+		generatedTitles[row.id] = row.title;
+	}
+
+	// Resolve titles for completed generated stories not in the recent fetch above
+	// (UUID ids we don't yet have a title for). One batch query, server-side.
+	const missingTitleIds = [
+		...new Set(
+			(storyCompletions.data ?? [])
+				.map((r) => r.story_id as string)
+				.filter((id) => UUID_RE.test(id) && !(id in generatedTitles) && !dailyChallengeStoryIds.has(id))
+		)
+	];
+	if (missingTitleIds.length > 0) {
+		const { data: extraStories } = await supabase
+			.from('generated_story')
+			.select('id, title, description')
+			.in('id', missingTitleIds);
+		for (const row of extraStories ?? []) {
+			if (isDailyChallengeStory(row)) {
+				dailyChallengeStoryIds.add(row.id);
+			} else {
+				generatedTitles[row.id] = row.title;
+			}
+		}
+	}
+
+	// Story completions (any story finished, hardcoded or generated)
+	for (const row of storyCompletions.data ?? []) {
+		const storyId: string = row.story_id;
+		if (dailyChallengeStoryIds.has(storyId)) continue;
+		// Never show a raw UUID: use the resolved title, or a generic label for
+		// unresolved generated stories; prettify only real (slug) ids.
+		const title = generatedTitles[storyId] || (UUID_RE.test(storyId) ? 'Story' : prettifySlug(storyId));
+		items.push({
+			id: `story-done-${storyId}-${row.completed_at}`,
+			type: 'story',
+			icon: '📖',
+			title,
+			subtitle: 'Story completed',
+			timestamp: row.completed_at,
+			href: storyHref(storyId),
+			status: 'completed'
+		});
+	}
+
+	// Tutor conversations
+	for (const row of tutorConversations.data ?? []) {
+		const topics = Array.isArray(row.topics_discussed) ? row.topics_discussed.filter(Boolean) : [];
+		const subtitle = topics.length
+			? topics.slice(0, 3).join(', ')
+			: `Tutor chat · ${dialectLabel(row.dialect)}`;
+		items.push({
+			id: `tutor-${row.id}`,
+			type: 'tutor',
+			icon: '💬',
+			title: row.summary || `Tutor chat · ${dialectLabel(row.dialect)}`,
+			subtitle,
+			timestamp: row.created_at,
+			href: `/tutor?conversationId=${row.id}`
+		});
+	}
+
+	// Structured lessons (seconds -> ms)
+	for (const row of lessonProgress.data ?? []) {
+		const tsSec = row.last_accessed_at ?? row.completed_at ?? row.started_at;
+		if (!tsSec) continue;
+		items.push({
+			id: `lesson-${row.topic_id}-${tsSec}`,
+			type: 'lesson',
+			icon: '📚',
+			title: topicTitles[row.topic_id] || 'Lesson',
+			subtitle: `Lesson · ${dialectLabel(row.dialect)}${row.status === 'completed' ? ' · completed' : row.status === 'in_progress' ? ' · in progress' : ''}`,
+			timestamp: tsSec * 1000,
+			href: `/lessons/structured/${row.dialect}?lessonId=${row.topic_id}`,
+			status: row.status
+		});
+	}
+
+	// Games (resumable via resumeId)
+	for (const row of gameProgress.data ?? []) {
+		const params = new URLSearchParams({
+			resumeId: row.id,
+			dialect: row.dialect,
+			category: row.category,
+			mode: row.game_mode
+		});
+		items.push({
+			id: `game-${row.id}`,
+			type: 'game',
+			icon: '🎮',
+			title: `${prettifySlug(row.category)} game`,
+			subtitle: `${dialectLabel(row.dialect)} · ${row.game_mode}${row.status === 'completed' ? ` · score ${row.score}/${row.total_questions}` : ' · in progress'}`,
+			timestamp: row.last_played_at,
+			href: `/learn/game/play?${params.toString()}`,
+			status: row.status
+		});
+	}
+
+	// Ephemeral surfaces: one synthesized item per active day, linking to a fresh session.
+	for (const row of dailyActivity.data ?? []) {
+		const ts: number = row.activity_date;
+		if (row.reviews_count > 0) {
+			items.push({
+				id: `review-${ts}`,
+				type: 'review',
+				icon: '🧠',
+				title: `Reviewed ${row.reviews_count} ${row.reviews_count === 1 ? 'word' : 'words'}`,
+				subtitle: 'Vocab review · start a new session',
+				timestamp: ts,
+				href: '/review'
+			});
+		}
+		if (row.sentences_viewed > 0) {
+			items.push({
+				id: `sentences-${ts}`,
+				type: 'sentences',
+				icon: '📝',
+				title: `Practiced ${row.sentences_viewed} ${row.sentences_viewed === 1 ? 'sentence' : 'sentences'}`,
+				subtitle: 'Sentences · start a new session',
+				timestamp: ts,
+				href: '/sentences'
+			});
+		}
+	}
+
+	// Sort newest-first, then group by calendar day.
+	items.sort((a, b) => b.timestamp - a.timestamp);
+
+	const days: HistoryDay[] = [];
+	let current: HistoryDay | null = null;
+	for (const item of items) {
+		const key = dayKeyFor(item.timestamp);
+		if (!current || current.dayKey !== key) {
+			current = { dayKey: key, dayLabel: dayLabelFor(item.timestamp), items: [] };
+			days.push(current);
+		}
+		current.items.push(item);
+	}
+
+	return {
+		session,
+		user,
+		days
+	};
+};

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
+
+	const hasHistory = $derived(data.days.length > 0);
+</script>
+
+<section class="min-h-screen">
+	<header class="max-w-3xl mx-auto px-4 sm:px-8 pt-10 pb-8 border-b border-tile-500">
+		<h1 class="text-4xl sm:text-5xl font-black text-text-300 tracking-tight leading-tight">
+			History
+		</h1>
+		<p class="mt-3 text-text-200 text-base sm:text-lg max-w-lg leading-relaxed">
+			Your activity from the last 30 days. Pick up where you left off.
+		</p>
+	</header>
+
+	<div class="max-w-3xl mx-auto px-4 sm:px-8 py-8">
+		{#if !hasHistory}
+			<div class="flex flex-col items-center text-center bg-tile-400 border border-tile-500 rounded-2xl px-6 py-16">
+				<div class="text-5xl mb-4">🕊️</div>
+				<h2 class="text-xl font-bold text-text-300 mb-2">No activity yet</h2>
+				<p class="text-text-200 max-w-sm leading-relaxed">
+					Read a story, take a lesson, play a game, or chat with the tutor — it'll show up here, grouped by day.
+				</p>
+			</div>
+		{:else}
+			{#each data.days as day (day.dayKey)}
+				<div class="mb-8">
+					<h2 class="text-[11px] uppercase tracking-[0.2em] text-text-200 font-bold mb-3">
+						{day.dayLabel}
+					</h2>
+
+					<div class="flex flex-col gap-2">
+						{#each day.items as item (item.id)}
+							<a
+								href={item.href}
+								class="group flex items-center gap-4 bg-tile-400 border border-tile-500 rounded-xl px-4 py-3 shadow-sm transition-all duration-200 hover:bg-tile-500 hover:shadow-md active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-300"
+							>
+								<span
+									class="grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-tile-300 text-xl leading-none"
+									aria-hidden="true"
+								>
+									{item.icon}
+								</span>
+
+								<div class="min-w-0 flex-1">
+									<p class="text-sm sm:text-base font-semibold text-text-300 truncate">
+										{item.title}
+									</p>
+									<p class="text-xs sm:text-sm text-text-200 truncate">
+										{item.subtitle}
+									</p>
+								</div>
+
+								<svg
+									class="h-4 w-4 flex-shrink-0 text-text-200 transition-transform duration-200 group-hover:translate-x-0.5"
+									fill="none"
+									stroke="currentColor"
+									viewBox="0 0 24 24"
+									aria-hidden="true"
+								>
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+								</svg>
+							</a>
+						{/each}
+					</div>
+				</div>
+			{/each}
+		{/if}
+	</div>
+</section>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import Button from '$lib/components/Button.svelte';
+	import Testimonial from '$lib/components/Testimonial.svelte';
 	import type { ActionData } from './$types';
 	import { Browser } from '@capacitor/browser';
 	import { App } from '@capacitor/app';
@@ -340,6 +341,11 @@
         </button>
       </div>
     </form>
+    <Testimonial
+      segments={[
+        { t: 'This is great! As someone outgrowing Duolingo this is perfect.', b: true }
+      ]}
+    />
     <div>
       <div class="grid grid-cols-2 gap-4 flex-1 content-start">
         {#each bottomFeatures as feature}
@@ -352,8 +358,8 @@
       </div>
     </div>
     </div>
-    <div class="flex-1">
-      <div class="grid grid-cols-2 gap-4 flex-1 content-start">
+    <div class="flex-1 flex flex-col gap-4">
+      <div class="grid grid-cols-2 gap-4 content-start">
         {#each topFeatures as feature}
           <div class="bg-tile-400 border-2 border-tile-600 rounded-lg p-5 shadow-lg">
             <div class="text-2xl mb-2">{feature.icon}</div>
@@ -362,6 +368,12 @@
           </div>
         {/each}
       </div>
+      <Testimonial
+        segments={[
+          { t: "Even though I'm a beginner, " },
+          { t: "your AI is the best I've tried among all the apps!", b: true }
+        ]}
+      />
     </div>
   </div>
 </section>

--- a/src/routes/signup/+page.svelte
+++ b/src/routes/signup/+page.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import Button from '$lib/components/Button.svelte';
+	import Testimonial from '$lib/components/Testimonial.svelte';
 	import type { ActionData } from './$types';
 	import { Browser } from '@capacitor/browser';
 	import { App } from '@capacitor/app';
@@ -172,6 +173,14 @@
           <a href="/login" class="text-text-200 hover:text-text-300 underline transition-colors">Already have an account? Login</a>
         </div>
       </form>
+      <Testimonial
+        segments={[
+          { t: 'After only a day, I love Parallel Arabic.', b: true },
+          {
+            t: ' As a language teacher and an absolute language nut who speaks seven other languages besides Arabic, I can tell how much thought went into this.'
+          }
+        ]}
+      />
       <div>
         <div class="grid grid-cols-2 gap-4 flex-1 content-start">
           {#each bottomFeatures as feature}
@@ -184,8 +193,8 @@
         </div>
       </div>
     </div>
-    <div class="flex-1">
-      <div class="grid grid-cols-2 gap-4 flex-1 content-start">
+    <div class="flex-1 flex flex-col gap-4">
+      <div class="grid grid-cols-2 gap-4 content-start">
         {#each topFeatures as feature}
           <div class="bg-tile-400 border-2 border-tile-600 rounded-lg p-5 shadow-lg">
             <div class="text-2xl mb-2">{feature.icon}</div>
@@ -194,6 +203,13 @@
           </div>
         {/each}
       </div>
+      <Testimonial
+        segments={[
+          { t: 'I love it! This is something I have been ' },
+          { t: 'searching for ages', b: true },
+          { t: ' :) thank you so much' }
+        ]}
+      />
     </div>
   </div>
 </section>

--- a/src/routes/tutor/+page.server.ts
+++ b/src/routes/tutor/+page.server.ts
@@ -1,6 +1,8 @@
 import type { PageServerLoad } from "./$types";
 import { supabase } from '$lib/supabaseClient';
 import { downloadStoryFromStorage } from '$lib/helpers/storage-helpers';
+import { getConversationMessages } from '$lib/utils/tutor-memory';
+import type { ConversationMessage } from '$lib/types/index';
 
 interface PracticeSentence {
   id: string;
@@ -26,14 +28,49 @@ interface RecentConversation {
   topics_discussed: string[] | null;
 }
 
-export const load: PageServerLoad = async ({ parent }) => {
+export const load: PageServerLoad = async ({ parent, url }) => {
   // Get session and subscription info from parent layout
   const { session, isSubscribed, user } = await parent();
-  
+
+  // Resume a past conversation when deep-linked via ?conversationId=...
+  let resumeConversation: ConversationMessage[] | null = null;
+  let resumeConversationId: string | null = null;
+  let resumeDialect: string | null = null;
+  const conversationIdParam = url.searchParams.get('conversationId');
+
+  if (user?.id && conversationIdParam) {
+    try {
+      // Verify the conversation belongs to this user before loading it.
+      const { data: convo } = await supabase
+        .from('tutor_conversation')
+        .select('id, dialect')
+        .eq('id', conversationIdParam)
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (convo) {
+        const messages = await getConversationMessages(convo.id);
+        resumeConversation = messages.map((m) => ({
+          id: m.id,
+          type: m.role,
+          arabic: m.arabic ?? undefined,
+          english: m.english ?? undefined,
+          transliteration: m.transliteration ?? undefined,
+          feedback: m.feedback ?? undefined,
+          timestamp: new Date(m.created_at)
+        }));
+        resumeConversationId = convo.id;
+        resumeDialect = convo.dialect;
+      }
+    } catch (e) {
+      console.error('Error loading conversation to resume:', e);
+    }
+  }
+
   // Fetch learning insights and recent conversations if user is logged in
   let learningInsights: LearningInsight[] = [];
   let recentConversations: RecentConversation[] = [];
-  
+
   if (user?.id) {
     try {
       // Fetch in parallel for speed
@@ -132,7 +169,10 @@ export const load: PageServerLoad = async ({ parent }) => {
     user,
     practiceSentences,
     learningInsights,
-    recentConversations
+    recentConversations,
+    resumeConversation,
+    resumeConversationId,
+    resumeDialect
   };
 };
 

--- a/src/routes/tutor/+page.svelte
+++ b/src/routes/tutor/+page.svelte
@@ -5,8 +5,10 @@
   import RecordButton from '$lib/components/RecordButton.svelte';
   import AudioLoading from '$lib/components/AudioLoading.svelte';
   import AudioButton from '$lib/components/AudioButton.svelte';
+  import Similarity from '$lib/components/Similarity.svelte';
   import MessageBubble from '$lib/components/tutor/ConversationMessage.svelte';
   import PaywallModal from '$lib/components/PaywallModal.svelte';
+  import Modal from '$lib/components/Modal.svelte';
   import DialectComparisonModal from '$lib/components/dialect-shared/sentences/DialectComparisonModal.svelte';
   import DefinitionModal from '$lib/components/dialect-shared/sentences/DefinitionModal.svelte';
   import ConversationSummaryModal from '$lib/components/ConversationSummaryModal.svelte';
@@ -16,6 +18,7 @@
   import { updateKeyboardStyle } from '$lib/helpers/update-keyboard-style';
   import { trackEvent } from '$lib/analytics';
   import { TUTOR_SCENARIOS, type TutorScenario } from '$lib/constants/tutor-scenarios';
+  import levenshtein from 'fast-levenshtein';
 
   let { data } = $props();
 
@@ -130,7 +133,7 @@
   let mode = $state<TutorMode>('conversation');
 
   let selectedDialect = $state<Dialect>(
-    (get(tutorSelectedDialect) as Dialect) || (getDefaultDialect(data.user) as Dialect)
+    (data.resumeDialect as Dialect) || (get(tutorSelectedDialect) as Dialect) || (getDefaultDialect(data.user) as Dialect)
   );
 
   // Scenario picker state (beginner conversation starters)
@@ -169,14 +172,181 @@
     activeScenarioContext ? activeScenarioContext.dialogs[selectedDialect] ?? null : null
   );
 
+  // ── Scenario Learn phase (vocab intro before the guided conversation) ──────
+  // When a scenario starts, the tutor first walks the learner through the key
+  // vocab and a few practice sentences (AI-generated) that build on those words,
+  // having them repeat each one aloud before the roleplay conversation begins.
+  interface ScenarioVocabItem {
+    arabic: string;
+    transliteration: string;
+    english: string;
+    teachingLine: string;
+    kind: 'word' | 'sentence';
+  }
+  const PRONUNCIATION_THRESHOLD = 60;
+  const MAX_ATTEMPTS_BEFORE_SKIP = 3;
+  let scenarioPhase = $state<'learn' | 'practice' | null>(null);
+  // Ordered list of learn items: the words first, then the practice sentences.
+  let scenarioVocab = $state<ScenarioVocabItem[]>([]);
+  let isLoadingVocab = $state(false);
+  let vocabError = $state<string | null>(null);
+  let currentVocabIndex = $state(0);
+  let vocabAttempts = $state(0);
+  let vocabResult = $state<{ similarity: number; passed: boolean } | null>(null);
+
+  let currentVocabItem = $derived(scenarioVocab[currentVocabIndex] ?? null);
+  let canSkipVocab = $derived(vocabAttempts >= MAX_ATTEMPTS_BEFORE_SKIP);
+
+  // Custom scenario: the learner describes what they want to talk about and we
+  // build an ad-hoc scenario that runs through the same Learn → Practice flow.
+  let showCustomScenarioModal = $state(false);
+  let customScenarioText = $state('');
+
+  function createCustomScenario() {
+    const text = customScenarioText.trim();
+    if (!text) return;
+
+    const scenario: TutorScenario = {
+      id: 'custom-' + Date.now(),
+      title: text.length > 60 ? text.slice(0, 60) + '…' : text,
+      emoji: '✨',
+      description: text,
+      level: 'beginner',
+      dialogs: {
+        [selectedDialect]: { otherRoleEnglish: 'Conversation partner', lines: [] }
+      }
+    };
+
+    trackEvent('tutor_custom_scenario_created', { dialect: selectedDialect });
+    showCustomScenarioModal = false;
+    customScenarioText = '';
+    startScenario(scenario);
+  }
+
   function startScenario(scenario: TutorScenario) {
     const dialog = scenario.dialogs[selectedDialect];
     if (!dialog) return;
 
     trackEvent('tutor_scenario_started', { scenario_id: scenario.id, dialect: selectedDialect });
     activeScenarioContext = scenario;
+    scenarioPhase = 'learn';
+    currentVocabIndex = 0;
+    vocabAttempts = 0;
+    vocabResult = null;
+    scenarioVocab = [];
+    currentHint = null;
+    fetchScenarioVocab();
+  }
+
+  // Fetch the AI-generated vocab list the learner repeats before the roleplay.
+  async function fetchScenarioVocab() {
+    if (!activeScenarioContext) return;
+    const dialog = activeScenarioContext.dialogs[selectedDialect];
+    if (!dialog) return;
+
+    isLoadingVocab = true;
+    vocabError = null;
+    trackEvent('scenario_vocab_started', { scenario_id: activeScenarioContext.id, dialect: selectedDialect });
+
+    try {
+      const r = await fetch('/api/scenario-intro', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dialect: selectedDialect,
+          scenarioTitle: activeScenarioContext.title,
+          scenarioDescription: activeScenarioContext.description,
+          lines: dialog.lines,
+          proficiencyLevel: data.user?.proficiency_level || 'A1'
+        })
+      });
+      if (!r.ok) throw new Error('Failed to load vocab');
+      const d = await r.json();
+      const words = Array.isArray(d.vocab) ? d.vocab : [];
+      const sentences = Array.isArray(d.sentences) ? d.sentences : [];
+      // Words first, then practice sentences that build on them.
+      scenarioVocab = [
+        ...words.map((w: Omit<ScenarioVocabItem, 'kind'>) => ({ ...w, kind: 'word' as const })),
+        ...sentences.map((s: Omit<ScenarioVocabItem, 'kind'>) => ({ ...s, kind: 'sentence' as const }))
+      ];
+      if (scenarioVocab.length === 0) {
+        // Nothing to teach — go straight into the conversation.
+        beginPracticePhase();
+      }
+    } catch (e) {
+      console.error('Scenario vocab error:', e);
+      vocabError = "Couldn't load the vocabulary. Retry, or skip straight to the conversation.";
+    } finally {
+      isLoadingVocab = false;
+    }
+  }
+
+  // Character-level similarity for single vocab words. Word-level matching
+  // (calculateSimilarity) is too strict here — one differing letter scores 0%.
+  // Normalize away tashkeel + common letter variants that speech-to-text drops,
+  // then use Levenshtein for partial credit (same approach as /speak).
+  function calculateWordSimilarity(transcribed: string, expected: string): number {
+    const normalize = (text: string) =>
+      text
+        .replace(/[ً-ْ]/g, '') // tashkeel/diacritics
+        .replace(/[آأإٱ]/g, 'ا') // أ إ آ ٱ → ا
+        .replace(/ى/g, 'ي') // ى → ي
+        .replace(/ة/g, 'ه') // ة → ه
+        .replace(/ـ/g, '') // tatweel
+        .replace(/[،.؟!,?]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    const t = normalize(transcribed);
+    const e = normalize(expected);
+    if (!t || !e) return 0;
+    if (t === e) return 100;
+
+    const distance = levenshtein.get(t, e);
+    const maxLength = Math.max(t.length, e.length);
+    return Math.max(0, Math.round((1 - distance / maxLength) * 100));
+  }
+
+  // Score the learner's spoken attempt at the current vocab word.
+  function scoreLearnAttempt(transcript: string) {
+    if (!currentVocabItem) return;
+    const similarity = calculateWordSimilarity(transcript, currentVocabItem.arabic);
+    const passed = similarity >= PRONUNCIATION_THRESHOLD;
+    vocabAttempts += 1;
+    vocabResult = { similarity, passed };
+    trackEvent('scenario_vocab_attempt', {
+      similarity,
+      passed,
+      word_index: currentVocabIndex,
+      dialect: selectedDialect
+    });
+  }
+
+  // Move to the next vocab word, or start the conversation after the last one.
+  function advanceVocab() {
+    if (currentVocabIndex < scenarioVocab.length - 1) {
+      currentVocabIndex += 1;
+      vocabAttempts = 0;
+      vocabResult = null;
+    } else {
+      beginPracticePhase();
+    }
+  }
+
+  function skipVocabWord() {
+    trackEvent('scenario_vocab_skipped', { word_index: currentVocabIndex, dialect: selectedDialect });
+    advanceVocab();
+  }
+
+  // Transition out of the Learn phase into the existing guided conversation.
+  function beginPracticePhase() {
+    scenarioPhase = 'practice';
     hintsVisible = true;
     currentHint = null;
+    trackEvent('scenario_practice_started', { scenario_id: activeScenarioContext?.id, dialect: selectedDialect });
+
+    const dialog = activeScenarioContext?.dialogs[selectedDialect];
+    if (!dialog) return;
 
     // Seed the very first hint from the hardcoded scenario data: the first
     // student line. After the student records and the AI replies, subsequent
@@ -214,6 +384,13 @@
   function exitScenario() {
     trackEvent('tutor_scenario_exited', { scenario_id: activeScenarioContext?.id, dialect: selectedDialect });
     activeScenarioContext = null;
+    scenarioPhase = null;
+    scenarioVocab = [];
+    currentVocabIndex = 0;
+    vocabAttempts = 0;
+    vocabResult = null;
+    isLoadingVocab = false;
+    vocabError = null;
     currentHint = null;
     isLoadingHint = false;
   }
@@ -290,9 +467,16 @@
   let discardRecording = false;
   let mediaRecorder: MediaRecorder | null = $state(null);
   let audioChunks: Blob[] = $state([]);
-  // Initialized from the in-memory stores so the chat survives navigation
-  let conversation: ConversationMessage[] = $state(get(tutorConversation) as ConversationMessage[]);
-  let conversationId: string | null = $state(get(tutorConversationId)); // Track conversation ID for memory
+  // Initialized from a deep-linked past conversation (History) when present,
+  // otherwise from the in-memory stores so the chat survives navigation.
+  let conversation: ConversationMessage[] = $state(
+    (data.resumeConversation as ConversationMessage[] | null)?.length
+      ? (data.resumeConversation as ConversationMessage[])
+      : (get(tutorConversation) as ConversationMessage[])
+  );
+  let conversationId: string | null = $state(
+    data.resumeConversationId ?? get(tutorConversationId)
+  ); // Track conversation ID for memory
 
   // Keep the stores in sync with local state (browser only; reassignments above trigger this)
   $effect(() => {
@@ -695,7 +879,11 @@
       }
 
       isTranscribing = false;
-      await sendUserMessage(userMessage, recordingLanguage);
+      if (scenarioPhase === 'learn') {
+        scoreLearnAttempt(userMessage);
+      } else {
+        await sendUserMessage(userMessage, recordingLanguage);
+      }
     } catch (error) {
       console.error('Error processing recording:', error);
       const noSpeech = error instanceof Error && error.message === 'No text transcribed';
@@ -730,7 +918,8 @@
           message: userMessage,
           dialect: selectedDialect,
           conversation: conversationHistory,
-          conversationId: conversationId
+          conversationId: conversationId,
+          proficiencyLevel: data.user?.proficiency_level || 'A1'
         })
       });
       if (!r.ok) throw new Error('Failed to get tutor response');
@@ -959,6 +1148,22 @@
     }
   }
 
+  // Learn-phase record control: always Arabic, and clear the previous score so
+  // the UI returns to its "now you try" state for a fresh attempt.
+  function toggleLearnRecording() {
+    if (!hasActiveSubscription && !recording) {
+      openPaywallModal();
+      return;
+    }
+
+    if (recording) {
+      stopRecording();
+    } else {
+      vocabResult = null;
+      startRecording('ar');
+    }
+  }
+
   async function clearConversation() {
     // Show summary if we have any messages at all
     if (conversation.length >= 2) {
@@ -1162,6 +1367,42 @@
   error={comparisonError}
   currentDialect={selectedDialect}
 />
+
+<Modal
+  isOpen={showCustomScenarioModal}
+  handleCloseModal={() => (showCustomScenarioModal = false)}
+  width="min(90%, 480px)"
+>
+  <div class="p-6">
+    <h2 class="text-lg font-bold text-text-300 flex items-center gap-2 mb-1">
+      <span>✨</span> Create your own scenario
+    </h2>
+    <p class="text-sm text-text-200 mb-4 leading-relaxed">
+      Describe what you'd like to talk about. Your tutor will teach you the key words and
+      sentences first, then practise the conversation with you.
+    </p>
+    <textarea
+      bind:value={customScenarioText}
+      rows="3"
+      placeholder="e.g., Ordering coffee and asking for the wifi password"
+      onkeydown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') createCustomScenario(); }}
+      class="block w-full text-base text-text-300 bg-tile-200 border-2 border-tile-500 rounded-xl p-3 focus:border-tile-700 focus:outline-none focus:ring-2 focus:ring-tile-600/50 transition-all placeholder:text-text-100 resize-none"
+    ></textarea>
+    <div class="flex justify-end gap-2 mt-4">
+      <button
+        type="button"
+        onclick={() => { showCustomScenarioModal = false; customScenarioText = ''; }}
+        class="px-4 py-2 bg-tile-500 text-text-300 font-medium rounded-xl hover:bg-tile-600 transition-colors"
+      >Cancel</button>
+      <button
+        type="button"
+        onclick={createCustomScenario}
+        disabled={!customScenarioText.trim()}
+        class="px-5 py-2 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >Start →</button>
+    </div>
+  </div>
+</Modal>
 
 <section class="min-h-screen bg-tile-200">
   <!-- Compact header: title + dialect picker -->
@@ -1459,22 +1700,26 @@
                   <span class="text-xl shrink-0">{activeScenarioContext.emoji}</span>
                   <div class="min-w-0">
                     <p class="text-xs font-semibold text-text-300 truncate">
-                      Practicing: {activeScenarioContext.title}
+                      {scenarioPhase === 'learn' ? 'Learning' : 'Practicing'}: {activeScenarioContext.title}
                     </p>
                     <p class="text-[11px] text-text-200 truncate">
-                      Tutor is playing: {activeScenarioDialog.otherRoleEnglish}
+                      {scenarioPhase === 'learn'
+                        ? 'New words first, then the conversation'
+                        : `Tutor is playing: ${activeScenarioDialog.otherRoleEnglish}`}
                     </p>
                   </div>
                 </div>
                 <div class="flex items-center gap-1.5 shrink-0">
-                  <button
-                    type="button"
-                    onclick={toggleHints}
-                    class="text-[11px] px-2 py-1 rounded-md font-medium bg-tile-500 hover:bg-tile-600 text-text-300 transition-colors"
-                    aria-pressed={hintsVisible}
-                  >
-                    {hintsVisible ? 'Hide hints' : 'Show hints'}
-                  </button>
+                  {#if scenarioPhase !== 'learn'}
+                    <button
+                      type="button"
+                      onclick={toggleHints}
+                      class="text-[11px] px-2 py-1 rounded-md font-medium bg-tile-500 hover:bg-tile-600 text-text-300 transition-colors"
+                      aria-pressed={hintsVisible}
+                    >
+                      {hintsVisible ? 'Hide hints' : 'Show hints'}
+                    </button>
+                  {/if}
                   <button
                     type="button"
                     onclick={exitScenario}
@@ -1488,7 +1733,119 @@
           </div>
         
         <div bind:this={transcriptContainer} class="p-4">
-          {#if conversation.length === 0 && !activeScenarioContext && !isTranscribing && !isGettingResponse && !chatError}
+          {#if scenarioPhase === 'learn'}
+            <div class="max-w-xl mx-auto py-4">
+              {#if isLoadingVocab}
+                <div class="flex flex-col items-center justify-center min-h-[300px] text-center gap-3">
+                  <span class="text-4xl animate-bounce">📚</span>
+                  <p class="text-text-300 font-semibold">Preparing your words & sentences…</p>
+                  <p class="text-text-200 text-sm">Your tutor is choosing the words and practice sentences you'll need for this conversation.</p>
+                </div>
+              {:else if vocabError}
+                <div class="bg-rose-500/10 border-2 border-rose-500/40 rounded-xl p-4 text-center">
+                  <p class="text-sm font-medium text-text-300 mb-3">{vocabError}</p>
+                  <div class="flex justify-center gap-2">
+                    <button
+                      type="button"
+                      onclick={fetchScenarioVocab}
+                      class="text-xs px-3 py-1.5 bg-emerald-600 text-white rounded-lg font-semibold hover:bg-emerald-700 transition-colors"
+                    >Retry</button>
+                    <button
+                      type="button"
+                      onclick={beginPracticePhase}
+                      class="text-xs px-3 py-1.5 bg-tile-500 text-text-300 rounded-lg font-medium hover:bg-tile-600 transition-colors"
+                    >Skip to conversation</button>
+                  </div>
+                </div>
+              {:else if currentVocabItem}
+                <div class="flex items-center justify-between mb-2">
+                  <div class="flex items-center gap-2">
+                    <span class="text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full {currentVocabItem.kind === 'sentence' ? 'bg-sky-500/15 text-sky-700' : 'bg-emerald-500/15 text-emerald-700'}">
+                      {currentVocabItem.kind === 'sentence' ? '💬 Practice sentence' : '🔤 New word'}
+                    </span>
+                    <span class="text-xs font-semibold text-text-200">{currentVocabIndex + 1} of {scenarioVocab.length}</span>
+                  </div>
+                  <button
+                    type="button"
+                    onclick={beginPracticePhase}
+                    class="text-xs text-text-200 hover:text-text-300 underline underline-offset-2"
+                  >Skip intro →</button>
+                </div>
+                <div class="h-1.5 w-full bg-tile-500 rounded-full overflow-hidden mb-6">
+                  <div class="h-full bg-emerald-500 transition-all duration-300" style="width: {(currentVocabIndex / scenarioVocab.length) * 100}%"></div>
+                </div>
+
+                <div class="bg-tile-300 border-2 border-tile-500 rounded-2xl p-6 text-center">
+                  <p class="text-text-200 text-sm mb-4 leading-relaxed">{currentVocabItem.teachingLine}</p>
+                  <p class="font-bold text-text-300 mb-2 {currentVocabItem.kind === 'sentence' ? 'text-2xl leading-relaxed' : 'text-4xl'}" dir="rtl">{currentVocabItem.arabic}</p>
+                  <p class="text-lg text-text-200 mb-1">{currentVocabItem.transliteration}</p>
+                  <p class="text-sm text-text-200 mb-5">{currentVocabItem.english}</p>
+                  <div class="flex justify-center">
+                    <AudioButton text={currentVocabItem.arabic} dialect={selectedDialect}>Hear it</AudioButton>
+                  </div>
+                </div>
+
+                <div class="mt-6 flex flex-col items-center gap-4">
+                  {#if vocabResult}
+                    <div class="flex flex-col items-center gap-2">
+                      <Similarity score={vocabResult.similarity} />
+                      <p class="text-sm font-semibold {vocabResult.passed ? 'text-emerald-600' : 'text-orange-500'}">
+                        {vocabResult.passed ? 'Nice — that sounded great!' : 'Not quite — listen again and repeat.'}
+                      </p>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      {#if vocabResult.passed}
+                        <button
+                          type="button"
+                          onclick={advanceVocab}
+                          class="px-5 py-2.5 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-colors"
+                        >{currentVocabIndex < scenarioVocab.length - 1 ? 'Next →' : 'Start conversation →'}</button>
+                      {:else}
+                        <button
+                          type="button"
+                          onclick={toggleLearnRecording}
+                          disabled={isProcessing}
+                          class="px-5 py-2.5 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >Try again</button>
+                        {#if canSkipVocab}
+                          <button
+                            type="button"
+                            onclick={skipVocabWord}
+                            class="px-4 py-2.5 bg-tile-500 text-text-300 font-medium rounded-xl hover:bg-tile-600 transition-colors"
+                          >Skip</button>
+                        {/if}
+                      {/if}
+                    </div>
+                  {:else}
+                    <button
+                      type="button"
+                      onclick={toggleLearnRecording}
+                      disabled={isProcessing}
+                      class="flex items-center justify-center gap-3 px-6 py-3 rounded-xl border-2 font-semibold text-text-300 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed {recording ? 'border-red-500 bg-red-500/15 shadow-lg' : 'border-tile-600 bg-tile-300 hover:bg-tile-500'}"
+                      aria-label={recording ? 'Stop recording' : 'Record your pronunciation'}
+                    >
+                      {#if recording}
+                        <span class="w-2.5 h-2.5 bg-red-500 rounded-full animate-pulse"></span>
+                        <span class="tabular-nums text-sm">{formatRecordingTime(recordingSeconds)}</span>
+                        <span class="text-sm font-medium">Listening — tap when done</span>
+                      {:else if isProcessing}
+                        <AudioLoading />
+                        <span class="text-sm font-medium">Checking…</span>
+                      {:else}
+                        <RecordButton />
+                        <span>Now you try</span>
+                      {/if}
+                    </button>
+                    {#if !hasActiveSubscription}
+                      <p class="text-xs text-text-200 text-center">
+                        🔒 <button type="button" class="underline underline-offset-2 hover:text-text-300" onclick={openPaywallModal}>Subscribe</button> to practice speaking
+                      </p>
+                    {/if}
+                  {/if}
+                </div>
+              {/if}
+            </div>
+          {:else if conversation.length === 0 && !activeScenarioContext && !isTranscribing && !isGettingResponse && !chatError}
             <div class="flex flex-col items-center justify-start h-full min-h-[400px] text-center py-6">
               <div class="text-6xl mb-4">👋</div>
               <h3 class="text-xl font-bold text-text-300 mb-2">Start a Conversation</h3>
@@ -1519,6 +1876,19 @@
                         </div>
                       </button>
                     {/each}
+
+                    <!-- Custom scenario CTA -->
+                    <button
+                      type="button"
+                      onclick={() => (showCustomScenarioModal = true)}
+                      class="group flex items-start gap-3 p-4 bg-sky-500/5 rounded-xl border-2 border-dashed border-sky-500/40 hover:bg-sky-500/10 hover:border-sky-500/60 hover:shadow-lg transition-all duration-200 text-left active:scale-95"
+                    >
+                      <span class="text-3xl shrink-0 transition-transform duration-200 group-hover:scale-110">✨</span>
+                      <div class="min-w-0">
+                        <p class="text-sm font-semibold text-text-300 mb-1">Create your own</p>
+                        <p class="text-xs text-text-200 leading-snug">Describe what you want to talk about and practice it.</p>
+                      </div>
+                    </button>
                   </div>
                 </div>
               {/if}
@@ -1643,7 +2013,9 @@
         </div>
 
         <!-- Composer: mic + language toggle, or typed input. Sticks to the viewport
-             bottom (above the mobile nav) so it's always reachable while the page scrolls. -->
+             bottom (above the mobile nav) so it's always reachable while the page scrolls.
+             Hidden during the Learn phase, which has its own record control. -->
+        {#if scenarioPhase !== 'learn'}
         <div class="border-t-2 border-tile-600 bg-tile-400 p-3 sm:p-4 sticky bottom-16 lg:bottom-0 z-30 rounded-b-lg">
           <div class="max-w-3xl mx-auto">
             {#if inputMode === 'text'}
@@ -1764,123 +2136,10 @@
             {/if}
           </div>
         </div>
+        {/if}
       </div>
       {/if}
 
-      <!-- Below the conversation: tips + learning profile -->
-      <div class="grid sm:grid-cols-2 gap-6 mt-6 items-start">
-        <!-- Tips Card -->
-        <div class="bg-tile-400 border-2 border-tile-600 rounded-lg shadow-lg overflow-hidden">
-          <div class="p-4 border-b border-tile-600">
-            <h3 class="text-sm font-bold text-text-300 flex items-center gap-2">
-              <span>💡</span> Tips
-            </h3>
-          </div>
-          <div class="p-4 space-y-2 text-sm text-text-200">
-            {#if mode === 'conversation'}
-              <p>• Tap the <strong class="text-text-300">mic button</strong> below the conversation to speak</p>
-              <p>• Switch the toggle to <strong class="text-text-300">EN</strong> to ask "How do I say...?"</p>
-              <p>• Click any word in responses for definitions</p>
-              <p>• Use the <strong class="text-text-300">العربية / English / Translit</strong> toggles above the conversation to hide or show each line</p>
-            {:else}
-              <p>• First, <strong class="text-text-300">listen</strong> to the sentence using the speaker button</p>
-              <p>• Then <strong class="text-text-300">record yourself</strong> saying the sentence</p>
-              <p>• Compare your pronunciation with the original</p>
-              <p>• Use the navigation to try different sentences</p>
-            {/if}
-          </div>
-        </div>
 
-        <!-- Learning Memory Card - Only show if there's data -->
-        {#if (learningInsights.length > 0 || recentConversations.length > 0) && mode === 'conversation'}
-          <div class="bg-tile-400 border-2 border-tile-600 rounded-lg shadow-lg overflow-hidden">
-            <div class="p-4 border-b border-tile-600">
-              <h3 class="text-sm font-bold text-text-300 flex items-center gap-2">
-                <span>🧠</span> Your Learning Profile
-              </h3>
-            </div>
-            <div class="p-4 space-y-4">
-              <!-- User Profile Summary -->
-              {#if data.user}
-                <div class="text-xs text-text-200 space-y-1">
-                  {#if data.user.proficiency_level}
-                    <p><span class="font-semibold text-text-300">Level:</span> {data.user.proficiency_level}</p>
-                  {/if}
-                  {#if data.user.current_streak > 0}
-                    <p><span class="font-semibold text-text-300">🔥 Streak:</span> {data.user.current_streak} days</p>
-                  {/if}
-                </div>
-              {/if}
-
-              <!-- Areas to Improve -->
-              {#if learningInsights.filter(i => i.insight_type === 'weakness').length > 0}
-                <div>
-                  <p class="text-xs font-semibold text-amber-400 mb-1.5">Areas to Focus On:</p>
-                  <ul class="text-xs text-text-200 space-y-1">
-                    {#each learningInsights.filter(i => i.insight_type === 'weakness').slice(0, 3) as insight}
-                      <li class="flex items-start gap-1.5">
-                        <span class="text-amber-400">•</span>
-                        <span>{insight.content}</span>
-                      </li>
-                    {/each}
-                  </ul>
-                </div>
-              {/if}
-
-              <!-- Strengths -->
-              {#if learningInsights.filter(i => i.insight_type === 'strength').length > 0}
-                <div>
-                  <p class="text-xs font-semibold text-emerald-600 mb-1.5">Your Strengths:</p>
-                  <ul class="text-xs text-text-200 space-y-1">
-                    {#each learningInsights.filter(i => i.insight_type === 'strength').slice(0, 3) as insight}
-                      <li class="flex items-start gap-1.5">
-                        <span class="text-emerald-600">✓</span>
-                        <span>{insight.content}</span>
-                      </li>
-                    {/each}
-                  </ul>
-                </div>
-              {/if}
-
-              <!-- Topics of Interest -->
-              {#if learningInsights.filter(i => i.insight_type === 'topic_interest').length > 0}
-                <div>
-                  <p class="text-xs font-semibold text-sky-400 mb-1.5">Topics You Like:</p>
-                  <div class="flex flex-wrap gap-1">
-                    {#each learningInsights.filter(i => i.insight_type === 'topic_interest').slice(0, 5) as insight}
-                      <span class="px-2 py-0.5 bg-sky-500/20 text-sky-300 text-xs rounded-full">
-                        {insight.content}
-                      </span>
-                    {/each}
-                  </div>
-                </div>
-              {/if}
-
-              <!-- Recent Sessions -->
-              {#if recentConversations.length > 0}
-                <div>
-                  <p class="text-xs font-semibold text-text-300 mb-1.5">Recent Sessions:</p>
-                  <div class="space-y-2">
-                    {#each recentConversations.slice(0, 3) as conv}
-                      <div class="text-xs bg-tile-300/50 rounded-lg p-2 border border-tile-500/50">
-                        <p class="text-text-200 line-clamp-2">{conv.summary || 'Conversation with tutor'}</p>
-                        {#if conv.topics_discussed && conv.topics_discussed.length > 0}
-                          <div class="flex flex-wrap gap-1 mt-1">
-                            {#each conv.topics_discussed.slice(0, 3) as topic}
-                              <span class="px-1.5 py-0.5 bg-tile-500/50 text-text-300 text-[10px] rounded">
-                                {topic}
-                              </span>
-                            {/each}
-                          </div>
-                        {/if}
-                      </div>
-                    {/each}
-                  </div>
-                </div>
-              {/if}
-            </div>
-          </div>
-        {/if}
-      </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

Adds a **Learn phase** to Beginner Scenarios and improves AI tutor quality/reliability. (Also bundles in-progress auth/navigation/onboarding/history work that was in the working tree — see last section.)

### Scenario Learn phase
- Tapping a scenario now opens a **Learn phase** before the guided conversation: an AI-generated set of **key vocab words + a few practice sentences that build on them**, which the learner repeats aloud.
- Pronunciation is scored with normalized character-level Levenshtein (handles tashkeel / alef / taa-marbuta variants from speech-to-text). Pass a threshold to advance; **retry, with Skip after 3 attempts**.
- New endpoint `POST /api/scenario-intro` generates the vocab + sentences from the scenario's dialog (or a custom description). New `scenarioVocabSchema`.
- **Create your own scenario**: CTA + modal where the learner describes what they want to talk about; it runs through the same Learn → Practice flow.

### Tutor quality & reliability
- **Level calibration (`tutor-chat`)**: replies are now explicitly calibrated to the learner's CEFR level via a prominent top-of-prompt rule (A1 = one short sentence → C2 = full complexity). Level resolved from client → stored profile → A1, with a normalizer for both CEFR codes and word forms.
- **Better hints (`tutor-hint`)**: rewritten to keep the conversation going (ask a question back, add a detail, open a sub-topic) instead of dead-ending on "Thanks / I'm good".
- **"No response from Gemini" fix**: disabled the `gemini-2.5-flash` thinking budget on `tutor-chat`, `tutor-hint`, and `scenario-intro`. Thinking tokens were consuming the whole `maxOutputTokens`, leaving no text (finishReason MAX_TOKENS). Also raised token budgets. Improves reliability and latency.

## Verification
- `npm run check`: no new errors in the changed files (pre-existing project errors unchanged).
- Svelte autofixer run on `tutor/+page.svelte`: only pre-existing patterns flagged.
- Manual flow: pick dialect → scenario → Learn phase loads words+sentences → record/score with retry+skip → conversation begins. Custom scenario from modal works through the same flow.

## Note on scope
This PR also includes separate in-progress work that was uncommitted on the branch (not part of the tutor feature): `Navigation`, `Onboarding`, `AuthModal`, `PaywallModal`, `Sidebar`, `+layout`, `login`, `signup`, `tutor/+page.server.ts`, and new `history/` route, `MobileMenu`, `Testimonial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)